### PR TITLE
When streaming, call `onUpdate` one final time before completing

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -100,16 +100,17 @@ export class Client {
           }
 
           const completion = JSON.parse(ev.data) as CompletionResponse;
-          if (completion.stop_reason !== null) {
-            abortController.abort();
-            return resolve(completion);
-          }
 
           if (onUpdate) {
             Promise.resolve(onUpdate(completion)).catch((error) => {
               abortController.abort();
               reject(error);
             });
+          }
+
+          if (completion.stop_reason !== null) {
+            abortController.abort();
+            return resolve(completion);
           }
         },
         onerror: (error) => {


### PR DESCRIPTION
This avoids mistakes when using the SDK, where `onUpdate` is expected to be called with a complete sample eventually.