### PR TITLE
Make SDK throw actual JS Error instances on errors

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@anthropic-ai/sdk",
-  "version": "0.4.3",
+  "version": "0.4.4",
   "description": "Library for accessing the Anthropic API",
   "repository": "https://github.com/anthropics/anthropic-sdk-typescript",
   "license": "MIT",

--- a/src/index.ts
+++ b/src/index.ts
@@ -18,7 +18,7 @@ export type OnUpdate = (completion: CompletionResponse) => void | Promise<void>;
 export const HUMAN_PROMPT = "\n\nHuman:";
 export const AI_PROMPT = "\n\nAssistant:";
 
-const CLIENT_ID = "anthropic-typescript/0.4.3";
+const CLIENT_ID = "anthropic-typescript/0.4.4";
 const DEFAULT_API_URL = "https://api.anthropic.com";
 
 enum Event {
@@ -84,10 +84,9 @@ export class Client {
     return new Promise((resolve, reject) => {
       signal?.addEventListener("abort", (event) => {
         abortController.abort(event);
-        reject({
-          name: "AbortError",
-          message: "Caller aborted completeStream",
-        });
+        const error = new Error("AbortError: Caller aborted completeStream");
+        error.name = "AbortError";
+        reject(error);
       });
 
       fetchEventSource(`${this.apiUrl}/v1/complete`, {
@@ -104,7 +103,7 @@ export class Client {
           if (!response.ok) {
             abortController.abort();
             return reject(
-              Error(
+              new Error(
                 `Failed to open sampling stream, HTTP status code ${response.status}: ${response.statusText}`
               )
             );


### PR DESCRIPTION
There are a few instances where the SDK rejects with normal objects instead of instances of the JS `Error` class, which results in confusing issues when using the SDK downstream. I've updated that here.