### PR TITLE
feat(config): export `Config` type

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -7,7 +7,7 @@ import * as Errors from './error';
 import type { Agent } from '@anthropic-ai/sdk/_shims/agent';
 import * as Uploads from './uploads';
 
-type Config = {
+export type Config = {
   /**
    * Defaults to process.env["ANTHROPIC_API_KEY"]. Set it to null if you want to send unauthenticated requests.
    */


### PR DESCRIPTION
We're building an Anthropic integration for [Pezzo](https://pezzo.ai) and need to access the Anthropic `Config` object.

Since it isn't exported at the moment, we find ourselves having to duplicate the type, which is obviously less than ideal due to future deviations and having to keep up with the up-to-date type definition.

This PR exports it.