### PR TITLE
Fix header shadowing for edge functions

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -136,10 +136,10 @@ export class Anthropic extends Core.APIClient {
   }
 
   protected override validateHeaders(headers: Core.Headers, customHeaders: Core.Headers) {
-    if (this.apiKey && headers['X-Api-Key']) {
+    if (this.apiKey && headers['x-api-key']) {
       return;
     }
-    if (customHeaders['X-Api-Key'] === null) {
+    if (customHeaders['x-api-key'] === null) {
       return;
     }
 
@@ -173,7 +173,7 @@ export class Anthropic extends Core.APIClient {
     if (this.apiKey == null) {
       return {};
     }
-    return { 'X-Api-Key': this.apiKey };
+    return { 'x-api-key': this.apiKey };
   }
 
   protected bearerAuth(opts: Core.FinalRequestOptions): Core.Headers {

--- a/src/resources/beta/messages.ts
+++ b/src/resources/beta/messages.ts
@@ -28,14 +28,20 @@ export class Messages extends APIResource {
     options?: Core.RequestOptions,
   ): APIPromise<Message> | APIPromise<Stream<MessageStreamEvent>> {
     const { 'anthropic-beta': anthropicBeta, 'x-api-key': xAPIKey, ...body } = params;
+    const headers: Record<string, string> = {
+      'Anthropic-Beta': 'messages-2023-12-15',
+      'anthropic-beta': anthropicBeta,
+      ...options?.headers,
+    };
+    if (xAPIKey !== undefined) {
+      headers['x-api-key'] = xAPIKey;
+    }
     return this._client.post('/v1/messages', {
       body,
       timeout: 600000,
       ...options,
       headers: {
-        'Anthropic-Beta': 'messages-2023-12-15',
-        'anthropic-beta': anthropicBeta,
-        'x-api-key': xAPIKey || '',
+        ...headers,
         ...options?.headers,
       },
       stream: params.stream ?? false,

--- a/src/resources/completions.ts
+++ b/src/resources/completions.ts
@@ -24,11 +24,15 @@ export class Completions extends APIResource {
     options?: Core.RequestOptions,
   ): APIPromise<Completion> | APIPromise<Stream<Completion>> {
     const { 'x-api-key': xAPIKey, ...body } = params;
+    const headers: Record<string, string> = {};
+    if (xAPIKey !== undefined) {
+      headers['x-api-key'] = xAPIKey;
+    }
     return this._client.post('/v1/complete', {
       body,
       timeout: 600000,
       ...options,
-      headers: { 'x-api-key': xAPIKey || '', ...options?.headers },
+      headers: { ...headers, ...options?.headers },
       stream: params.stream ?? false,
     }) as APIPromise<Completion> | APIPromise<Stream<Completion>>;
   }


### PR DESCRIPTION
The newest SDK version seems to have added an issue where two variants of the `x-api-key` header get set:

```
{
      'Content-Length': '175',
      Accept: 'application/json',
      'Content-Type': 'application/json',
      'User-Agent': 'Anthropic/JS 0.11.0',
      'X-Stainless-Lang': 'js',
      'X-Stainless-Package-Version': '0.11.0',
      'X-Stainless-OS': 'MacOS',
      'X-Stainless-Arch': 'arm64',
      'X-Stainless-Runtime': 'node',
      'X-Stainless-Runtime-Version': 'v18.18.2',
      'X-Api-Key': '<secret key here>',
      'anthropic-version': '2023-06-01',
      'Anthropic-Beta': 'messages-2023-12-15',
      'anthropic-beta': 'messages-2023-12-15',
      'x-api-key': ''
}
```

This causes undefined behavior - it seems Node will dedupe using `X-Api-Key` while edge runtimes will use the lower cased version, resulting in mysterious auth issues.