### PR TITLE
--save hasn't been needed since 2017

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ The REST API documentation can be found [on docs.anthropic.com](https://docs.ant
 
 ```sh
 # install from NPM
-npm install --save @anthropic-ai/sdk
+npm install @anthropic-ai/sdk
 # or
 yarn add @anthropic-ai/sdk
 ```


### PR DESCRIPTION
The requirement was removed in the NPM 5.0.0 release.