### PR TITLE
fix: update `output_tokens` when streaming

### DIFF
--- a/src/lib/MessageStream.ts
+++ b/src/lib/MessageStream.ts
@@ -450,6 +450,7 @@ export class MessageStream implements AsyncIterable<MessageStreamEvent> {
       case 'message_delta':
         snapshot.stop_reason = event.delta.stop_reason;
         snapshot.stop_sequence = event.delta.stop_sequence;
+        snapshot.usage.output_tokens = event.usage.output_tokens;
         return snapshot;
       case 'content_block_start':
         snapshot.content.push(event.content_block);


### PR DESCRIPTION
## Summary

When using streaming API (`antrophic.messages.stream`), the final message (`stream.finalMessage()`) always reports single output token:

```
    // ...
    "model": "claude-3-sonnet-20240229",
    "stop_reason": "end_turn",
    "stop_sequence": null,
    "usage": {
      "input_tokens": 199,
      "output_tokens": 1
    }
```

## Fix 

On `message_delta` event update the `snapshot.usage.output_tokens` field from event output tokens.