### PR TITLE
Change "generated from our OpenAPI spec" to "generated from our Anthropic spec"

### DIFF
--- a/tests/api-resources/beta/prompt-caching/messages.test.ts
+++ b/tests/api-resources/beta/prompt-caching/messages.test.ts
@@ -1,4 +1,4 @@
-// File generated from our OpenAPI spec by Stainless. See CONTRIBUTING.md for details.
+// File generated from our Anthropic spec by Stainless. See CONTRIBUTING.md for details.
 
 import Anthropic from '@anthropic-ai/sdk';
 import { Response } from 'node-fetch';


### PR DESCRIPTION
Removed assumed erroneous reference to OpenAI