### PR TITLE
refactor(types): improve metadata types

### DIFF
--- a/api.md
+++ b/api.md
@@ -17,6 +17,7 @@ Types:
 - <code><a href="./src/resources/messages.ts">MessageStartEvent</a></code>
 - <code><a href="./src/resources/messages.ts">MessageStopEvent</a></code>
 - <code><a href="./src/resources/messages.ts">MessageStreamEvent</a></code>
+- <code><a href="./src/resources/messages.ts">Metadata</a></code>
 - <code><a href="./src/resources/messages.ts">Model</a></code>
 - <code><a href="./src/resources/messages.ts">RawContentBlockDeltaEvent</a></code>
 - <code><a href="./src/resources/messages.ts">RawContentBlockStartEvent</a></code>

--- a/src/index.ts
+++ b/src/index.ts
@@ -270,6 +270,7 @@ export namespace Anthropic {
   export import MessageStartEvent = API.MessageStartEvent;
   export import MessageStopEvent = API.MessageStopEvent;
   export import MessageStreamEvent = API.MessageStreamEvent;
+  export import Metadata = API.Metadata;
   export import Model = API.Model;
   export import RawContentBlockDeltaEvent = API.RawContentBlockDeltaEvent;
   export import RawContentBlockStartEvent = API.RawContentBlockStartEvent;

--- a/src/resources/beta/prompt-caching/messages.ts
+++ b/src/resources/beta/prompt-caching/messages.ts
@@ -413,7 +413,7 @@ export interface MessageCreateParamsBase {
   /**
    * An object describing metadata about the request.
    */
-  metadata?: MessageCreateParams.Metadata;
+  metadata?: MessagesAPI.Metadata;
 
   /**
    * Custom text sequences that will cause the model to stop generating.
@@ -562,18 +562,9 @@ export interface MessageCreateParamsBase {
 
 export namespace MessageCreateParams {
   /**
-   * An object describing metadata about the request.
+   * @deprecated use `Anthropic.Messages.Metadata` instead
    */
-  export interface Metadata {
-    /**
-     * An external identifier for the user who is associated with the request.
-     *
-     * This should be a uuid, hash value, or other opaque identifier. Anthropic may use
-     * this id to help detect abuse. Do not include any identifying information such as
-     * name, email address, or phone number.
-     */
-    user_id?: string | null;
-  }
+  export type Metadata = MessagesAPI.Metadata;
 
   /**
    * @deprecated use `Anthropic.Messages.ToolChoiceAuto` instead

--- a/src/resources/completions.ts
+++ b/src/resources/completions.ts
@@ -117,7 +117,7 @@ export interface CompletionCreateParamsBase {
   /**
    * An object describing metadata about the request.
    */
-  metadata?: CompletionCreateParams.Metadata;
+  metadata?: MessagesAPI.Metadata;
 
   /**
    * Sequences that will cause the model to stop generating.
@@ -174,18 +174,9 @@ export interface CompletionCreateParamsBase {
 
 export namespace CompletionCreateParams {
   /**
-   * An object describing metadata about the request.
+   * @deprecated use `Anthropic.Messages.Metadata` instead
    */
-  export interface Metadata {
-    /**
-     * An external identifier for the user who is associated with the request.
-     *
-     * This should be a uuid, hash value, or other opaque identifier. Anthropic may use
-     * this id to help detect abuse. Do not include any identifying information such as
-     * name, email address, or phone number.
-     */
-    user_id?: string | null;
-  }
+  export type Metadata = MessagesAPI.Metadata;
 
   export type CompletionCreateParamsNonStreaming = CompletionsAPI.CompletionCreateParamsNonStreaming;
   export type CompletionCreateParamsStreaming = CompletionsAPI.CompletionCreateParamsStreaming;

--- a/src/resources/index.ts
+++ b/src/resources/index.ts
@@ -23,6 +23,7 @@ export {
   MessageStartEvent,
   MessageStopEvent,
   MessageStreamEvent,
+  Metadata,
   Model,
   RawContentBlockDeltaEvent,
   RawContentBlockStartEvent,

--- a/src/resources/messages.ts
+++ b/src/resources/messages.ts
@@ -213,6 +213,17 @@ export type MessageStopEvent = RawMessageStopEvent;
 
 export type MessageStreamEvent = RawMessageStreamEvent;
 
+export interface Metadata {
+  /**
+   * An external identifier for the user who is associated with the request.
+   *
+   * This should be a uuid, hash value, or other opaque identifier. Anthropic may use
+   * this id to help detect abuse. Do not include any identifying information such as
+   * name, email address, or phone number.
+   */
+  user_id?: string | null;
+}
+
 /**
  * The model that will complete your prompt.\n\nSee
  * [models](https://docs.anthropic.com/en/docs/models-overview) for additional
@@ -576,7 +587,7 @@ export interface MessageCreateParamsBase {
   /**
    * An object describing metadata about the request.
    */
-  metadata?: MessageCreateParams.Metadata;
+  metadata?: Metadata;
 
   /**
    * Custom text sequences that will cause the model to stop generating.
@@ -725,18 +736,9 @@ export interface MessageCreateParamsBase {
 
 export namespace MessageCreateParams {
   /**
-   * An object describing metadata about the request.
+   * @deprecated use `Anthropic.Messages.ToolChoiceAuto` instead
    */
-  export interface Metadata {
-    /**
-     * An external identifier for the user who is associated with the request.
-     *
-     * This should be a uuid, hash value, or other opaque identifier. Anthropic may use
-     * this id to help detect abuse. Do not include any identifying information such as
-     * name, email address, or phone number.
-     */
-    user_id?: string | null;
-  }
+  export type Metadata = MessagesAPI.Metadata;
 
   /**
    * @deprecated use `Anthropic.Messages.ToolChoiceAuto` instead
@@ -794,6 +796,7 @@ export namespace Messages {
   export import MessageStartEvent = MessagesAPI.MessageStartEvent;
   export import MessageStopEvent = MessagesAPI.MessageStopEvent;
   export import MessageStreamEvent = MessagesAPI.MessageStreamEvent;
+  export import Metadata = MessagesAPI.Metadata;
   export import Model = MessagesAPI.Model;
   export import RawContentBlockDeltaEvent = MessagesAPI.RawContentBlockDeltaEvent;
   export import RawContentBlockStartEvent = MessagesAPI.RawContentBlockStartEvent;


### PR DESCRIPTION
We now properly define a single `Metadata` type instead of duplicating it everywhere.