### PR TITLE
fix(types): remove misleading betas TypedDict property for the Batch API

### DIFF
--- a/src/resources/beta/messages/batches.ts
+++ b/src/resources/beta/messages/batches.ts
@@ -343,7 +343,7 @@ export namespace BatchCreateParams {
      * See the [Messages API reference](/en/api/messages) for full documentation on
      * available parameters.
      */
-    params: BetaMessagesAPI.MessageCreateParamsNonStreaming;
+    params: Omit<BetaMessagesAPI.MessageCreateParamsNonStreaming, 'betas'>;
   }
 }
 


### PR DESCRIPTION
This wasn't actually supported:
```ts
  anthropic.beta.messages.batches.create({
    requests: [
      {
        custom_id: '...',
        params: {
          model: 'claude-3-5-sonnet-20240620',
          messages: [],
          max_tokens: 1024,
          betas: [],
        },
      },
    ],
  });
```