### PR TITLE
(fix): Add tool name for tool_use #emit.

### DIFF
--- a/src/lib/MessageStream.ts
+++ b/src/lib/MessageStream.ts
@@ -20,7 +20,7 @@ export interface MessageStreamEvents {
   streamEvent: (event: MessageStreamEvent, snapshot: Message) => void;
   text: (textDelta: string, textSnapshot: string) => void;
   citation: (citation: TextCitation, citationsSnapshot: TextCitation[]) => void;
-  inputJson: (partialJson: string, jsonSnapshot: unknown) => void;
+  inputJson: (partialJson: string, jsonSnapshot: unknown, toolName: string) => void;
   thinking: (thinkingDelta: string, thinkingSnapshot: string) => void;
   signature: (signature: string) => void;
   message: (message: Message) => void;
@@ -432,7 +432,7 @@ export class MessageStream implements AsyncIterable<MessageStreamEvent> {
           }
           case 'input_json_delta': {
             if (content.type === 'tool_use' && content.input) {
-              this._emit('inputJson', event.delta.partial_json, content.input);
+              this._emit('inputJson', event.delta.partial_json, content.input, content.name);
             }
             break;
           }


### PR DESCRIPTION
I noticed that when using `client.messages.stream`, the `inputJson` event does not return which tool to call. So, I added an extra parameter, `toolName`, to specify the tool to call in the stream.