### PR TITLE
Encode forward slashes in ARNs

### DIFF
--- a/packages/bedrock-sdk/src/client.ts
+++ b/packages/bedrock-sdk/src/client.ts
@@ -141,8 +141,12 @@ export class AnthropicBedrock extends Core.APIClient {
         throw new Error('Expected request body to be an object for post /v1/messages');
       }
 
-      const model = options.body['model'];
+      let model = options.body['model'];
       options.body['model'] = undefined;
+      // Encode any forward slashes in inference profile ARNs
+      if (model.includes('/')) {
+        model = model.replaceAll('/', '%2F');
+      }
 
       const stream = options.body['stream'];
       options.body['stream'] = undefined;


### PR DESCRIPTION
The underlying issue in https://github.com/anthropics/claude-code/issues/297 is because inference profile ARNs contain a `/`, but these are not being encoded properly right now and the generated path is invalid.

I did a simple string replace, because I'm not sure the rest of the ARN needs to be encoded, but happy to change as necessary!

Example:

```
import { AnthropicBedrock } from '@anthropic-ai/bedrock-sdk';

const client = new AnthropicBedrock();

async function main() {
  const message = await client.messages.create({
    model: process.env.MODEL,
    messages: [
      {
        role: 'user',
        content: 'Hello!',
      },
    ],
    max_tokens: 1024,
  });
  console.log(message);
}

main();
```

Before:

```
$ DEBUG=true MODEL=arn:aws:bedrock:us-east-1:id:application-inference-profile/xxx node index.js

Anthropic:DEBUG:request https://bedrock-runtime.us-east-1.amazonaws.com/model/arn:aws:bedrock:us-east-1:id:application-inference-profile/xxx/invoke {
...
```

After:

```
$ DEBUG=true MODEL=arn:aws:bedrock:us-east-1:id:application-inference-profile/xxx node index.js

Anthropic:DEBUG:request https://bedrock-runtime.us-east-1.amazonaws.com/model/arn:aws:bedrock:us-east-1:id:application-inference-profile%2Fxxx/invoke {
...
```