### PR TITLE
fix: correct streaming error message to link to TypeScript SDK docs

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -418,7 +418,7 @@ export class BaseAnthropic {
     if (expectedTimeout > defaultTimeout) {
       throw new Errors.AnthropicError(
         'Streaming is strongly recommended for operations that may take longer than 10 minutes. ' +
-          'See https://github.com/anthropics/anthropic-sdk-python#streaming-responses for more details',
+          'See https://github.com/anthropics/anthropic-sdk-typescript#streaming-responses for more details',
       );
     }
     return defaultTimeout * 1000;


### PR DESCRIPTION
Fixed incorrect documentation link in streaming timeout error message that was pointing to Python SDK docs instead of TypeScript SDK docs