### PR TITLE
fix: Add FileDocumentSource interface to DocumentBlockParam for file API support. Check for issue #773

### DIFF
--- a/src/resources/messages/messages.ts
+++ b/src/resources/messages/messages.ts
@@ -281,8 +281,14 @@ export interface ContentBlockSource {
 
 export type ContentBlockSourceContent = TextBlockParam | ImageBlockParam;
 
+export interface FileDocumentSource {
+  file_id: string;
+
+  type: 'file';
+}
+
 export interface DocumentBlockParam {
-  source: Base64PDFSource | PlainTextSource | ContentBlockSource | URLPDFSource;
+  source: Base64PDFSource | PlainTextSource | ContentBlockSource | URLPDFSource | FileDocumentSource;
 
   type: 'document';
 


### PR DESCRIPTION

This PR fixes issue #773 by adding support for the file API in the DocumentBlockParam interface.

Changes:
- added FileDocumentSource interface w/ file_id and type properties
- updated DocumentBlockParam to include FileDocumentSource as a possible source type (Optional, i would say)

