### PR TITLE
feat: update streaming error message to say 'required' not 'recommended'

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -441,7 +441,7 @@ export class BaseAnthropic {
     const expectedTimeout = (60 * 60 * maxTokens) / 128_000;
     if (expectedTimeout > defaultTimeout) {
       throw new Errors.AnthropicError(
-        'Streaming is strongly recommended for operations that may take longer than 10 minutes. ' +
+        'Streaming is required for operations that may take longer than 10 minutes. ' +
           'See https://github.com/anthropics/anthropic-sdk-typescript#streaming-responses for more details',
       );
     }
@@ -802,7 +802,7 @@ export class BaseAnthropic {
     const expectedTime = (maxTime * maxTokens) / 128000;
     if (expectedTime > defaultTime || (maxNonstreamingTokens != null && maxTokens > maxNonstreamingTokens)) {
       throw new Errors.AnthropicError(
-        'Streaming is strongly recommended for operations that may token longer than 10 minutes. See https://github.com/anthropics/anthropic-sdk-typescript#long-requests for more details',
+        'Streaming is required for operations that may take longer than 10 minutes. See https://github.com/anthropics/anthropic-sdk-typescript#long-requests for more details',
       );
     }
 


### PR DESCRIPTION
Updates the error message from 'streaming is strongly recommended' to 'streaming is required' for consistency across all Anthropic SDKs.

## Changes
Changes the error message in timeout calculation functions from 'strongly recommended' to 'required' when streaming is needed for operations that may take longer than 10 minutes. Also fixes a typo: 'may token longer' -> 'may take longer'.

## Related
CE-732

🤖 Generated with [Claude Code](https://claude.ai/code)