### PR TITLE
docs: fix default timeout comment

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -802,7 +802,7 @@ export class BaseAnthropic {
   }
 
   public calculateNonstreamingTimeout(maxTokens: number, maxNonstreamingTokens?: number): number {
-    const maxTime = 60 * 60 * 1000; // 10 minutes
+    const maxTime = 60 * 60 * 1000; // 60 minutes
     const defaultTime = 60 * 10 * 1000; // 10 minutes
 
     const expectedTime = (maxTime * maxTokens) / 128000;


### PR DESCRIPTION
Correcting comment related to default timeout calculation. Currently `calculateNonstreamingTimeout` has `const maxTime = 60 * 60 * 1000; // 10 minutes` which is misleading since that is actually 60 minutes :)