### PR TITLE
fix(vertex): extract model from request body for count_tokens endpoint

### DIFF
--- a/packages/vertex-sdk/src/client.ts
+++ b/packages/vertex-sdk/src/client.ts
@@ -179,7 +179,13 @@ export class AnthropicVertex extends BaseAnthropic {
         );
       }
 
-      options.path = `/projects/${this.projectId}/locations/${this.region}/publishers/anthropic/models/count-tokens:rawPredict`;
+      if (!isObj(options.body)) {
+        throw new Error('Expected request body to be an object for post /v1/messages/count_tokens');
+      }
+
+      const model = options.body['model'];
+
+      options.path = `/projects/${this.projectId}/locations/${this.region}/publishers/anthropic/models/${model}:rawPredict`;
     }
 
     return super.buildRequest(options);


### PR DESCRIPTION
## Problem
The `countTokens()` method on Vertex AI fails with "Requested entity was not found" error.

**Root cause:** The SDK hardcodes `"count-tokens"` as the model name in the API path instead of using the actual model from the request body.

## Reproduction
```typescript
const client = new AnthropicVertex({ region: 'us-east5' });
await client.beta.messages.countTokens({
  model: 'claude-sonnet-4-5@20250929',  // User provides actual model
  messages: [{ role: 'user', content: 'test' }],
});
// Error: Requested entity was not found
// Because SDK calls: .../models/count-tokens:rawPredict
// Instead of: .../models/claude-sonnet-4-5@20250929:rawPredict
```

## Solution
Extract the model from `options.body['model']` and use it in the path construction, matching the pattern used by the regular messages endpoint (lines 151-170).

## Changes
- Extract model from request body in count_tokens handler
- Add validation for request body object
- Use actual model in path construction instead of hardcoded "count-tokens"

## Testing
- [x] Existing tests pass
- [ ] Manual testing with real Vertex AI project (requires Vertex credentials)

## Related
- Fixes #593

🤖 Generated with [Claude Code](https://claude.com/claude-code)