### PR TITLE
fix: update MessageStream to not create unhandled rejections with .withResponse()

### DIFF
--- a/.stats.yml
+++ b/.stats.yml
@@ -1,4 +1,4 @@
 configured_endpoints: 26
-openapi_spec_url: https://storage.googleapis.com/stainless-sdk-openapi-specs/anthropic%2Fanthropic-fcf7231118f0af5d687971176bdce5a7a5effd1ba4d9fb937f30f26289f35d6b.yml
+openapi_spec_url: https://storage.googleapis.com/stainless-sdk-openapi-specs/anthropic%2Fanthropic-bf322c093e459a35404f84c71dbdf4133c6d1ec0e2c8b0a52226a672344a1a97.yml
 openapi_spec_hash: 592d90505082223899e0638ad56ba162
-config_hash: 98e00a1d3d57d183719c637f0c623535
+config_hash: 9f18bb8d1f1cf1e270e8e0783e4f5ee4

--- a/.stats.yml
+++ b/.stats.yml
@@ -1,4 +1,4 @@
 configured_endpoints: 26
 openapi_spec_url: https://storage.googleapis.com/stainless-sdk-openapi-specs/anthropic%2Fanthropic-bf322c093e459a35404f84c71dbdf4133c6d1ec0e2c8b0a52226a672344a1a97.yml
 openapi_spec_hash: 592d90505082223899e0638ad56ba162
-config_hash: 9f18bb8d1f1cf1e270e8e0783e4f5ee4
+config_hash: acb0dc6d0506ef5b69e9e895d65f743a

--- a/.stats.yml
+++ b/.stats.yml
@@ -1,4 +1,4 @@
 configured_endpoints: 26
-openapi_spec_url: https://storage.googleapis.com/stainless-sdk-openapi-specs/anthropic%2Fanthropic-9c7d1ea59095c76b24f14fe279825c2b0dc10f165a973a46b8a548af9aeda62e.yml
+openapi_spec_url: https://storage.googleapis.com/stainless-sdk-openapi-specs/anthropic%2Fanthropic-fcf7231118f0af5d687971176bdce5a7a5effd1ba4d9fb937f30f26289f35d6b.yml
 openapi_spec_hash: 592d90505082223899e0638ad56ba162
-config_hash: e0f97b085ca213c87341488cb257ed57
+config_hash: 98e00a1d3d57d183719c637f0c623535

--- a/scripts/utils/upload-artifact.sh
+++ b/scripts/utils/upload-artifact.sh
@@ -12,9 +12,11 @@ if [[ "$SIGNED_URL" == "null" ]]; then
   exit 1
 fi
 
-UPLOAD_RESPONSE=$(tar "${BASE_PATH:+-C$BASE_PATH}" -cz "${ARTIFACT_PATH:-dist}" | curl -v -X PUT \
+TARBALL=$(cd dist && npm pack --silent)
+
+UPLOAD_RESPONSE=$(curl -v -X PUT \
   -H "Content-Type: application/gzip" \
-  --data-binary @- "$SIGNED_URL" 2>&1)
+  --data-binary "@dist/$TARBALL" "$SIGNED_URL" 2>&1)
 
 if echo "$UPLOAD_RESPONSE" | grep -q "HTTP/[0-9.]* 200"; then
   echo -e "\033[32mUploaded build to Stainless storage.\033[0m"

--- a/src/internal/to-file.ts
+++ b/src/internal/to-file.ts
@@ -73,7 +73,7 @@ export type ToFileInput =
 
 /**
  * Helper for creating a {@link File} to pass to an SDK upload method from a variety of different data formats
- * @param value the raw content of the file.  Can be an {@link Uploadable}, {@link BlobLikePart}, or {@link AsyncIterable} of {@link BlobLikePart}s
+ * @param value the raw content of the file. Can be an {@link Uploadable}, BlobLikePart, or AsyncIterable of BlobLikeParts
  * @param {string=} name the name of the file. If omitted, toFile will try to determine a file name from bits if possible
  * @param {Object=} options additional properties
  * @param {string=} options.type the MIME type of the content

--- a/src/lib/BetaMessageStream.ts
+++ b/src/lib/BetaMessageStream.ts
@@ -113,6 +113,8 @@ export class BetaMessageStream implements AsyncIterable<BetaMessageStreamEvent> 
     response: Response;
     request_id: string | null | undefined;
   }> {
+    this.#catchingPromiseCreated = true;
+
     const response = await this.#connectedPromise;
     if (!response) {
       throw new Error('Could not resolve a `Response` object');

--- a/src/lib/MessageStream.ts
+++ b/src/lib/MessageStream.ts
@@ -112,6 +112,8 @@ export class MessageStream implements AsyncIterable<MessageStreamEvent> {
     response: Response;
     request_id: string | null | undefined;
   }> {
+    this.#catchingPromiseCreated = true;
+
     const response = await this.#connectedPromise;
     if (!response) {
       throw new Error('Could not resolve a `Response` object');

--- a/src/lib/tools/BetaToolRunner.ts
+++ b/src/lib/tools/BetaToolRunner.ts
@@ -105,6 +105,9 @@ export class BetaToolRunner<Stream extends boolean> {
           if (params.stream) {
             stream = this.client.beta.messages.stream({ ...params }, this.#options);
             this.#message = stream.finalMessage();
+            // Make sure that this promise doesn't throw before we get the option to do something about it.
+            // Error will be caught when we call await this.#message ultimately
+            this.#message.catch(() => {});
             yield stream as any;
           } else {
             this.#message = this.client.beta.messages.create({ ...params, stream: false }, this.#options);

--- a/src/lib/tools/ToolRunner.ts
+++ b/src/lib/tools/ToolRunner.ts
@@ -97,6 +97,9 @@ export class BetaToolRunner<Stream extends boolean> {
           if (params.stream) {
             stream = this.client.beta.messages.stream({ ...params });
             this.#message = stream.finalMessage();
+            // Make sure that this promise doesn't throw before we get the option to do something about it.
+            // Error will be caught when we call await this.#message ultimately
+            this.#message.catch(() => {});
             yield stream as any;
           } else {
             this.#message = this.client.beta.messages.create({ ...params, stream: false });

--- a/src/resources/beta/beta.ts
+++ b/src/resources/beta/beta.ts
@@ -204,7 +204,8 @@ export type AnthropicBeta =
   | 'interleaved-thinking-2025-05-14'
   | 'code-execution-2025-05-22'
   | 'extended-cache-ttl-2025-04-11'
-  | 'context-1m-2025-08-07';
+  | 'context-1m-2025-08-07'
+  | 'context-management-2025-06-27';
 
 export interface BetaAPIError {
   message: string;

--- a/src/resources/beta/beta.ts
+++ b/src/resources/beta/beta.ts
@@ -205,7 +205,8 @@ export type AnthropicBeta =
   | 'code-execution-2025-05-22'
   | 'extended-cache-ttl-2025-04-11'
   | 'context-1m-2025-08-07'
-  | 'context-management-2025-06-27';
+  | 'context-management-2025-06-27'
+  | 'model-context-window-exceeded-2025-08-26';
 
 export interface BetaAPIError {
   message: string;

--- a/tests/api-resources/MessageStream.test.ts
+++ b/tests/api-resources/MessageStream.test.ts
@@ -170,6 +170,29 @@ describe('MessageStream class', () => {
     await expect(runStream).rejects.toThrow(APIConnectionError);
   });
 
+  it('does not throw unhandled rejection with withResponse()', async () => {
+    // NOTE: this test fails if there is an uncaught exception
+
+    const { fetch, handleRequest } = mockFetch();
+
+    const anthropic = new Anthropic({ apiKey: '...', fetch });
+
+    const stream = anthropic.messages.stream(
+      {
+        max_tokens: 1024,
+        model: 'claude-3-7-sonnet-20250219',
+        messages: [{ role: 'user', content: 'Say hello there!' }],
+      },
+      { maxRetries: 0 },
+    );
+
+    handleRequest(async () => {
+      throw new Error('mock request error');
+    });
+
+    await expect(stream.withResponse()).rejects.toThrow(APIConnectionError);
+  });
+
   it('handles basic response fixture', async () => {
     const { fetch, handleStreamEvents } = mockFetch();
 


### PR DESCRIPTION
Fixed by treating `withResponse()` as a "catching promise" (which it is),
just like `done()`.

Fixes #829