### PR TITLE
refactor(structured outputs): rename `parsed` to `parsed_output`

### DIFF
--- a/src/helpers/beta/json-schema.ts
+++ b/src/helpers/beta/json-schema.ts
@@ -37,7 +37,7 @@ export function betaTool<const Schema extends Exclude<JSONSchema, boolean> & { t
 /**
  * Creates a JSON schema output format object from the given JSON schema.
  * If this is passed to the `.parse()` method then the response message will contain a
- * `.parsed` property that is the result of parsing the content with the given JSON schema.
+ * `.parsed_output` property that is the result of parsing the content with the given JSON schema.
  *
  */
 export function betaJSONSchemaOutputFormat<

--- a/src/helpers/beta/zod.ts
+++ b/src/helpers/beta/zod.ts
@@ -9,7 +9,7 @@ import { BetaToolResultContentBlockParam } from '../../resources/beta';
  * Creates a JSON schema output format object from the given Zod schema.
  *
  * If this is passed to the `.parse()` method then the response message will contain a
- * `.parsed` property that is the result of parsing the content with the given Zod object.
+ * `.parsed_output` property that is the result of parsing the content with the given Zod object.
  *
  * This can be passed directly to the `.create()` method but will not
  * result in any automatic parsing, you'll have to parse the response yourself.

--- a/src/lib/beta-parser.ts
+++ b/src/lib/beta-parser.ts
@@ -29,7 +29,7 @@ export type ParsedBetaMessage<ParsedT> = BetaMessage & {
 };
 
 export type ParsedBetaContentBlock<ParsedT> =
-  | (BetaTextBlock & { parsed: ParsedT | null })
+  | (BetaTextBlock & { parsed_output: ParsedT | null })
   | Exclude<BetaContentBlock, BetaTextBlock>;
 
 export function maybeParseBetaMessage<Params extends BetaParseableMessageCreateParams | null>(
@@ -41,7 +41,7 @@ export function maybeParseBetaMessage<Params extends BetaParseableMessageCreateP
       ...message,
       content: message.content.map((block) => {
         if (block.type === 'text') {
-          return Object.defineProperty({ ...block }, 'parsed', { value: null, enumerable: false });
+          return Object.defineProperty({ ...block }, 'parsed_output', { value: null, enumerable: false });
         }
         return block;
       }),
@@ -56,19 +56,19 @@ export function parseBetaMessage<Params extends BetaParseableMessageCreateParams
   message: BetaMessage,
   params: Params,
 ): ParsedBetaMessage<ExtractParsedContentFromBetaParams<Params>> {
-  let firstParsed: ReturnType<typeof parseBetaOutputFormat<Params>> | null = null;
+  let firstParsedOutput: ReturnType<typeof parseBetaOutputFormat<Params>> | null = null;
 
   const content: Array<ParsedBetaContentBlock<ExtractParsedContentFromBetaParams<Params>>> =
     message.content.map((block) => {
       if (block.type === 'text') {
-        const parsed = parseBetaOutputFormat(params, block.text);
+        const parsedOutput = parseBetaOutputFormat(params, block.text);
 
-        if (firstParsed === null) {
-          firstParsed = parsed;
+        if (firstParsedOutput === null) {
+          firstParsedOutput = parsedOutput;
         }
 
-        return Object.defineProperty({ ...block }, 'parsed', {
-          value: parsed,
+        return Object.defineProperty({ ...block }, 'parsed_output', {
+          value: parsedOutput,
           enumerable: false,
         }) as ParsedBetaContentBlock<ExtractParsedContentFromBetaParams<Params>>;
       }
@@ -78,7 +78,7 @@ export function parseBetaMessage<Params extends BetaParseableMessageCreateParams
   return {
     ...message,
     content,
-    parsed_output: firstParsed,
+    parsed_output: firstParsedOutput,
   } as ParsedBetaMessage<ExtractParsedContentFromBetaParams<Params>>;
 }
 

--- a/src/resources/beta/messages/messages.ts
+++ b/src/resources/beta/messages/messages.ts
@@ -149,9 +149,9 @@ export class Messages extends APIResource {
       ]),
     };
 
-    return this.create(params, options).then((message) => parseBetaMessage(message, params)) as APIPromise<
-      ParsedBetaMessage<ExtractParsedContentFromBetaParams<Params>>
-    >;
+    return this.create(params, options).then((message) =>
+      parseBetaMessage(message, params, { logger: this._client.logger ?? console }),
+    ) as APIPromise<ParsedBetaMessage<ExtractParsedContentFromBetaParams<Params>>>;
   }
 
   /**

--- a/src/resources/beta/messages/messages.ts
+++ b/src/resources/beta/messages/messages.ts
@@ -123,7 +123,7 @@ export class Messages extends APIResource {
 
   /**
    * Send a structured list of input messages with text and/or image content, along with an expected `output_format` and
-   * the response will be automatically parsed and available in the `parsed` property of the message.
+   * the response will be automatically parsed and available in the `parsed_output` property of the message.
    *
    * @example
    * ```ts
@@ -134,7 +134,7 @@ export class Messages extends APIResource {
    *   output_format: zodOutputFormat(z.object({ answer: z.number() }), 'math'),
    * });
    *
-   * console.log(message.parsed?.answer); // 4
+   * console.log(message.parsed_output?.answer); // 4
    * ```
    */
   parse<Params extends MessageCreateParamsNonStreaming>(

--- a/tests/lib/parser.test.ts
+++ b/tests/lib/parser.test.ts
@@ -105,7 +105,7 @@ describe('Parser', () => {
       expect(parsed.content[0]).toMatchObject({
         type: 'text',
         text: '{"city":"San Francisco","temperature":72}',
-        parsed: {
+        parsed_output: {
           city: 'San Francisco',
           temperature: 72,
         },
@@ -221,10 +221,10 @@ describe('Parser', () => {
       expect(parsed.parsed_output).toEqual({ city: 'San Francisco' });
       expect(parsed.content).toHaveLength(2);
       expect(parsed.content[0]).toMatchObject({
-        parsed: { city: 'San Francisco' },
+        parsed_output: { city: 'San Francisco' },
       });
       expect(parsed.content[1]).toMatchObject({
-        parsed: { city: 'Los Angeles' },
+        parsed_output: { city: 'Los Angeles' },
       });
     });
   });
@@ -287,7 +287,7 @@ describe('Parser', () => {
       expect(parsed.content[0]).toMatchObject({
         type: 'text',
         text: '{"city":"San Francisco"}',
-        parsed: null,
+        parsed_output: null,
       });
     });
 
@@ -296,7 +296,7 @@ describe('Parser', () => {
 
       expect(parsed.parsed_output).toBe(null);
       expect(parsed.content[0]).toMatchObject({
-        parsed: null,
+        parsed_output: null,
       });
     });
   });

--- a/tests/resources/beta/messages/parse.test.ts
+++ b/tests/resources/beta/messages/parse.test.ts
@@ -81,7 +81,7 @@ describe('Messages.parse()', () => {
     expect(result.content[0]).toMatchObject({
       type: 'text',
       text: '{"city":"San Francisco","temperature":72,"conditions":["sunny","clear"]}',
-      parsed: {
+      parsed_output: {
         city: 'San Francisco',
         temperature: 72,
         conditions: ['sunny', 'clear'],


### PR DESCRIPTION
This was an accident, we should use `.parsed_output` to make it more clear what it does, and to match the other SDKs.