### PR TITLE
feat(errors): add ignore_tool_parameter_parse_errors

### DIFF
--- a/src/core/error.ts
+++ b/src/core/error.ts
@@ -4,6 +4,8 @@ import { castToError } from '../internal/errors';
 
 export class AnthropicError extends Error {}
 
+export class UnableToParseToolParameterError extends AnthropicError {}
+
 export class APIError<
   TStatus extends number | undefined = number | undefined,
   THeaders extends Headers | undefined = Headers | undefined,

--- a/src/resources/beta/messages/messages.ts
+++ b/src/resources/beta/messages/messages.ts
@@ -3192,6 +3192,16 @@ export interface MessageCreateParamsBase {
    * Header param: Optional header to specify the beta version(s) you want to use.
    */
   betas?: Array<BetaAPI.AnthropicBeta>;
+
+
+  /**
+   * Body param: Whether to ignore tool parameter parse errors.
+   *
+   * If set to `true`, the model will ignore tool parameter parse errors and return them in the response.
+   *
+   * If set to `false`, the model will return an error if a tool parameter parse error occurs.
+   */
+  ignore_tool_parameter_parse_errors?: boolean;
 }
 
 export namespace MessageCreateParams {


### PR DESCRIPTION
…ageStream to handle parse errors

- Introduced UnableToParseToolParameterError for better error handling.
- Updated BetaMessageStream to conditionally ignore tool parameter parse errors based on new ignore_tool_parameter_parse_errors flag in MessageCreateParamsBase.
- Enhanced error handling during JSON parsing in BetaMessageStream.