### PR TITLE
skip events with no data while streaming

### DIFF
--- a/src/core/streaming.ts
+++ b/src/core/streaming.ts
@@ -66,6 +66,11 @@ export class Stream<Item> implements AsyncIterable<Item> {
             sse.event === 'content_block_delta' ||
             sse.event === 'content_block_stop'
           ) {
+            // skip streaming events with no data
+            if(sse.data == null) {
+              continue;
+            }
+
             try {
               yield JSON.parse(sse.data);
             } catch (e) {


### PR DESCRIPTION
In my cloud environment while using v0.71.2

I have continued to have the issue described [here](https://github.com/anthropics/anthropic-sdk-typescript/issues/292).

I have seen it occur both with content_block_delta and content_block_stop. 

Somewhat of note I have not got this running locally.  

Logs: 
```
Could not parse message into JSON:
From chunk: [ 'event: content_block_delta' ]
```
I believe this is somewhat normal server behavior when the server is responding for a long time basically the raw string for the sse shows that there is no data. I added a condition to skip this event only when streaming. 
