### PR TITLE
docs: fix typos

### DIFF
--- a/packages/bedrock-sdk/README.md
+++ b/packages/bedrock-sdk/README.md
@@ -19,7 +19,7 @@ npm install @anthropic-ai/bedrock-sdk
 import { AnthropicBedrock } from '@anthropic-ai/bedrock-sdk';
 
 // Note: this assumes you have configured AWS credentials in a way
-// that the AWS Node SDK will recognise, typicaly a shared `~/.aws/credentials`
+// that the AWS Node SDK will recognise, typically a shared `~/.aws/credentials`
 // file or `AWS_ACCESS_KEY_ID` & `AWS_SECRET_ACCESS_KEY` environment variables.
 //
 // https://docs.aws.amazon.com/sdk-for-javascript/v3/developer-guide/setting-credentials-node.html

--- a/src/lib/environments/worker.ts
+++ b/src/lib/environments/worker.ts
@@ -21,6 +21,7 @@ import { copyClientForHelper } from '../helper-client';
 import type { AgentToolContext } from '../../tools/agent-toolset/node';
 
 const HEARTBEAT_DEFAULT_MS = 30_000;
+const HEARTBEAT_TTL_DEFAULT_MS = 90_000;
 const NO_HEARTBEAT_SENTINEL = 'NO_HEARTBEAT';
 
 /**
@@ -348,7 +349,10 @@ async function forceStop(
 /**
  * Keep the work-item lease alive while a session is being served. Aborts `ctrl`
  * when the control plane reports the work is `stopping`/`stopped`, when the
- * lease is no longer extended, or on a permanent heartbeat failure.
+ * lease is no longer extended, on a permanent heartbeat failure, or when no
+ * heartbeat has succeeded for longer than the lease ttl (the lease is assumed
+ * lost). Each heartbeat call is cut off after the current beat interval so a
+ * hung request cannot outlive the lease it is meant to renew.
  */
 async function heartbeatLoop(
   client: Anthropic,
@@ -358,17 +362,26 @@ async function heartbeatLoop(
   requestOptions?: BetaToolRunnerRequestOptions,
 ): Promise<void> {
   let intervalMs = HEARTBEAT_DEFAULT_MS;
+  let ttlMs = HEARTBEAT_TTL_DEFAULT_MS;
+  let lastSuccessMs = Date.now();
   let last = NO_HEARTBEAT_SENTINEL;
   const beat = async (): Promise<void> => {
+    // Not the request `timeout` option: the core client retries timeouts, so
+    // it would not bound the call as a whole.
+    const beatCtrl = new AbortController();
+    const detach = linkAbort(ctrl.signal, beatCtrl);
+    const cutoff = setTimeout(() => beatCtrl.abort(), intervalMs);
     try {
       const resp = await client.beta.environments.work.heartbeat(
         work.id,
         { environment_id: work.environment_id, expected_last_heartbeat: last },
-        { ...requestOptions, headers: buildHeaders([requestOptions?.headers]), signal: ctrl.signal },
+        { ...requestOptions, headers: buildHeaders([requestOptions?.headers]), signal: beatCtrl.signal },
       );
+      lastSuccessMs = Date.now();
       last = resp.last_heartbeat;
       if (resp.ttl_seconds > 0) {
-        intervalMs = Math.max(1_000, Math.min((resp.ttl_seconds * 1000) / 2, HEARTBEAT_DEFAULT_MS));
+        ttlMs = resp.ttl_seconds * 1000;
+        intervalMs = Math.max(1_000, Math.min(ttlMs / 2, HEARTBEAT_DEFAULT_MS));
       }
       if (resp.state === 'stopping' || resp.state === 'stopped') {
         logger.info('heartbeat signals shutdown', { work_id: work.id, state: resp.state });
@@ -387,7 +400,19 @@ async function heartbeatLoop(
         ctrl.abort();
         throw e;
       }
+      if (Date.now() - lastSuccessMs > ttlMs) {
+        logger.error('lease assumed lost: no successful heartbeat in ttl', {
+          work_id: work.id,
+          ttl_ms: ttlMs,
+          error: String(e),
+        });
+        ctrl.abort();
+        return;
+      }
       logger.warn('transient heartbeat failure', { work_id: work.id, error: String(e) });
+    } finally {
+      clearTimeout(cutoff);
+      detach();
     }
   };
 

--- a/src/tools/agent-toolset/fs-util.ts
+++ b/src/tools/agent-toolset/fs-util.ts
@@ -24,12 +24,27 @@ async function realpathOrSelf(p: string): Promise<string> {
   }
 }
 
+/** Matches Linux MAXSYMLINKS, the threshold at which `realpath` itself reports ELOOP. */
+const MAX_SYMLINK_HOPS = 40;
+
+/** The `code` of a Node system error, or `undefined` for anything else. */
+export function errnoCode(err: unknown): string | undefined {
+  const code = (err as { code?: unknown } | null)?.code;
+  return typeof code === 'string' ? code : undefined;
+}
+
 /**
  * Fully resolve `abs`: `realpath` the longest existing ancestor and re-append
  * the rest, but never re-append a component that is itself a symlink — read the
  * link and continue from its target instead. This handles paths being created
  * (write/edit) without letting a symlink leaf (e.g. a dangling one pointing
  * outside a confinement root) slip through unresolved.
+ *
+ * Returns a symlink-free path or throws an errno-carrying error (`ELOOP` for a
+ * cycle or more than {@link MAX_SYMLINK_HOPS} links, the `lstat`/`realpath`
+ * error for an unreadable component); it never returns `abs` unresolved. Only
+ * symlink hops count against the cap, so any depth of not-yet-existing
+ * directories still resolves.
  */
 export async function canonicalize(abs: string): Promise<string> {
   const tail: string[] = [];
@@ -39,28 +54,24 @@ export async function canonicalize(abs: string): Promise<string> {
     let real: string;
     try {
       real = await fs.realpath(prefix);
-    } catch {
-      let isLink = false;
+    } catch (realpathErr) {
+      let isLink: boolean;
       try {
         isLink = (await fs.lstat(prefix)).isSymbolicLink();
-      } catch {
-        /* prefix truly doesn't exist (ENOENT) — fall through and walk up */
-      }
-      if (isLink) {
-        // Resolve the symlink ourselves and retry; `tail` (the part below it)
-        // still applies to the link's target. The hop cap matches Linux
-        // MAXSYMLINKS — the same threshold at which `realpath` itself would
-        // have returned ELOOP — so a cycle of unresolvable links terminates.
-        if (++hops > 40) {
-          throw new ToolError(`path ${JSON.stringify(abs)} has too many levels of symbolic links`);
-        }
-        prefix = path.resolve(path.dirname(prefix), await fs.readlink(prefix));
+      } catch (lstatErr) {
+        const code = errnoCode(lstatErr);
+        if (code !== 'ENOENT' && code !== 'ENOTDIR') throw lstatErr;
+        const parent = path.dirname(prefix);
+        if (parent === prefix) throw lstatErr;
+        tail.push(path.basename(prefix));
+        prefix = parent;
         continue;
       }
-      const parent = path.dirname(prefix);
-      if (parent === prefix) return abs; // walked past the FS root without a hit
-      tail.push(path.basename(prefix));
-      prefix = parent;
+      if (!isLink) throw realpathErr;
+      if (++hops > MAX_SYMLINK_HOPS) {
+        throw Object.assign(new Error('too many levels of symbolic links'), { code: 'ELOOP' });
+      }
+      prefix = path.resolve(path.dirname(prefix), await fs.readlink(prefix));
       continue;
     }
     return tail.length ? path.join(real, ...tail.reverse()) : real;
@@ -76,6 +87,9 @@ export async function canonicalize(abs: string): Promise<string> {
  * leaf, even a dangling one) is resolved before the confinement check, and the
  * resolved path is what the caller then operates on, so a symlink inside `root`
  * that points outside it can neither pass the check nor be followed afterwards.
+ * `..` is collapsed lexically before any symlink is followed. A path that cannot
+ * be resolved (symlink loop, unreadable component) is rejected with a
+ * `ToolError` naming `p`, never the host's absolute path.
  *
  * Residual TOCTOU: a component could still be swapped for a symlink between this
  * call and the eventual `fs` operation. Closing that fully needs per-component
@@ -91,7 +105,12 @@ export async function confineToRoot(
   const realRoot = await realpathOrSelf(path.resolve(root));
   const abs = path.resolve(realRoot, p);
   if (allowOutside) return abs;
-  const real = await canonicalize(abs);
+  let real: string;
+  try {
+    real = await canonicalize(abs);
+  } catch (err) {
+    throw new ToolError(fsErrorMessage(err, `path ${JSON.stringify(p)}`));
+  }
   if (real !== realRoot && !real.startsWith(realRoot + path.sep)) {
     throw new ToolError(`path ${JSON.stringify(p)} escapes workdir`);
   }
@@ -124,11 +143,12 @@ export async function atomicWriteFile(targetPath: string, content: string): Prom
 /**
  * Map a thrown filesystem error to a consistent, language-independent message,
  * so the model sees the same wording regardless of the runtime (Node's raw
- * `ENOENT: no such file...` text would otherwise leak through). Falls back to
- * the raw error message for codes we don't special-case.
+ * `ENOENT: no such file...` text would otherwise leak through). Codes we don't
+ * special-case render as the bare code, never Node's message, which embeds the
+ * host's absolute path.
  */
 export function fsErrorMessage(err: unknown, file: string): string {
-  const code = (err as { code?: string } | null)?.code;
+  const code = errnoCode(err);
   switch (code) {
     case 'ENOENT':
       return `${file}: no such file or directory`;
@@ -149,6 +169,6 @@ export function fsErrorMessage(err: unknown, file: string): string {
     case 'ENFILE':
       return `${file}: too many open files`;
     default:
-      return `${file}: ${err instanceof Error ? err.message : String(err)}`;
+      return `${file}: ${code !== undefined ? `i/o error (${code})` : 'i/o error'}`;
   }
 }

--- a/src/tools/agent-toolset/node.ts
+++ b/src/tools/agent-toolset/node.ts
@@ -470,7 +470,7 @@ export function betaReadTool(ctx: AgentToolContext): BetaRunnableTool {
         if (e instanceof ToolError) throw e;
         throw new ToolError(`read: ${fsErrorMessage(e, file_path)}`);
       }
-      if (!view_range) return data;
+      if (!view_range?.length) return data;
       if (view_range.length !== 2) throw new ToolError('read: view_range must be [start_line, end_line]');
       const [startLine, endLine] = view_range as [number, number];
       const lines = data.split('\n');

--- a/src/tools/agent-toolset/skills.ts
+++ b/src/tools/agent-toolset/skills.ts
@@ -15,7 +15,7 @@ import { pipeline } from 'node:stream/promises';
 import type { Anthropic } from '../../client';
 import { AnthropicError } from '../../core/error';
 import { loggerFor } from '../../internal/utils/log';
-import { DIR_CREATE_MODE } from './fs-util';
+import { DIR_CREATE_MODE, errnoCode } from './fs-util';
 import type { AgentToolContext } from './node';
 
 const execFileAsync = promisify(execFile);
@@ -115,8 +115,8 @@ export async function resolveSkillVersion(
 }
 
 /** Reject archive members that are absolute or contain a `..` component. */
-function assertSafeMemberNames(names: string): void {
-  for (const raw of names.split('\n')) {
+function assertSafeMemberNames(names: string[]): void {
+  for (const raw of names) {
     const entry = raw.trim();
     if (!entry) continue;
     if (path.isAbsolute(entry) || entry.split(/[\\/]/).includes('..')) {
@@ -125,19 +125,77 @@ function assertSafeMemberNames(names: string): void {
   }
 }
 
+const INCONSISTENT_LISTING = 'skill archive listing is inconsistent; refusing to extract';
+
 /**
- * Reject archives that contain anything other than regular files and
- * directories. The type char is the first byte of each `ls`-style line emitted
- * by `tar -tvf` / `unzip -Z`: `-` file, `d` dir, `l` symlink, `h` hardlink,
- * `b`/`c` device, `p` fifo, `s` socket. A symlink/hardlink member is how an
- * archive escapes its extraction dir even when no name contains `..`.
+ * Type chars (first byte of each `ls`-style line from `unzip -Z` / `tar -tvf`)
+ * that denote a regular file or directory. `zipinfo` prints `?` for entries
+ * with no Unix type bits, which `unzip` extracts as regular files; GNU tar
+ * prints `C` for contiguous files. Everything else — `l` symlink, `h`
+ * hardlink, `b`/`c` device, `p` fifo, `s` socket, unknown tar types — is a
+ * special member.
  */
-function assertNoSpecialMembers(verboseListing: string): void {
-  for (const line of verboseListing.split('\n')) {
-    const type = line.trimStart()[0];
-    if (type === 'l' || type === 'h' || type === 'b' || type === 'c' || type === 'p' || type === 's') {
-      throw new AnthropicError('refusing to extract archive with symlink/hardlink/device member');
+const PLAIN_TYPE_CHARS = { unzip: new Set(['-', 'd', '?']), tar: new Set(['-', 'd', 'C']) };
+
+function listingLines(listing: string): string[] {
+  const lines = listing.split('\n');
+  if (lines[lines.length - 1] === '') lines.pop();
+  return lines;
+}
+
+/**
+ * A special member is excluded by handing its listed name back to the CLI as
+ * a pattern, so the name must be byte-identical to what is stored. `tar`,
+ * `bsdtar` and `unzip` print bytes they cannot show literally as `\ooo`, `^X`
+ * or `#U` escapes, or as raw non-ASCII; any such name cannot be excluded
+ * reliably. A leading `-` would let `unzip` parse the pattern as an option.
+ */
+function canExcludeVerbatim(cmd: 'unzip' | 'tar', name: string): boolean {
+  return /^[\x20-\x7E]+$/.test(name) && !/[\\^#]/.test(name) && !(cmd === 'unzip' && name.startsWith('-'));
+}
+
+/**
+ * Pair an archive's name listing (`unzip -Z1` / `tar -tf`) with its typed
+ * listing (`unzip -Z --h --t` / `tar -tvf`) and split the members into plain
+ * (regular file or directory) and special (everything else). Special members
+ * are excluded from extraction rather than rejected; the archive is refused
+ * only when the two listings disagree in length or a special member's name
+ * cannot be passed back to the CLI verbatim (see {@link canExcludeVerbatim}).
+ */
+export function classifyArchiveListing(
+  cmd: 'unzip' | 'tar',
+  names: string,
+  typed: string,
+): { plain: string[]; special: string[] } {
+  const nameLines = listingLines(names);
+  const typedLines = listingLines(typed);
+  if (nameLines.length !== typedLines.length) throw new AnthropicError(INCONSISTENT_LISTING);
+  const plain: string[] = [];
+  const special: string[] = [];
+  nameLines.forEach((name, i) => {
+    if (PLAIN_TYPE_CHARS[cmd].has(typedLines[i]!.charAt(0))) {
+      plain.push(name);
+      return;
     }
+    if (!canExcludeVerbatim(cmd, name)) {
+      throw new AnthropicError(
+        `refusing to extract archive: cannot safely exclude member ${JSON.stringify(name)}`,
+      );
+    }
+    special.push(name);
+  });
+  return { plain, special };
+}
+
+/**
+ * Walk `dir` with `lstat` semantics and reject anything that is not a regular
+ * file or directory. Never follows a link and never descends into anything
+ * but a real directory.
+ */
+export async function assertOnlyPlainEntries(dir: string): Promise<void> {
+  for (const entry of await fs.readdir(dir, { withFileTypes: true })) {
+    if (entry.isDirectory()) await assertOnlyPlainEntries(path.join(dir, entry.name));
+    else if (!entry.isFile()) throw new AnthropicError(INCONSISTENT_LISTING);
   }
 }
 
@@ -152,7 +210,7 @@ async function runArchiveTool(cmd: 'unzip' | 'tar', args: string[]): Promise<str
     const { stdout } = await execFileAsync(cmd, args);
     return stdout;
   } catch (e) {
-    if (e != null && typeof e === 'object' && (e as { code?: unknown }).code === 'ENOENT') {
+    if (errnoCode(e) === 'ENOENT') {
       throw new AnthropicError(
         `skill extraction requires the \`${cmd}\` command, but it was not found on PATH`,
       );
@@ -162,17 +220,17 @@ async function runArchiveTool(cmd: 'unzip' | 'tar', args: string[]): Promise<str
 }
 
 /**
- * The single top-level directory shared by every entry in a newline-separated
- * archive listing, or `''` if entries don't all live under one common
- * directory. Skill bundles are packaged wrapped in one directory named after
- * the skill (e.g. `pdf/SKILL.md`, `pdf/scripts/...`); the extractor strips it
- * so contents land directly in the skill's dir instead of a redundant nested
- * `<skill>/<skill>/` level. A flat or multi-root archive yields `''`.
+ * The single top-level directory shared by every entry in an archive listing,
+ * or `''` if entries don't all live under one common directory. Skill bundles
+ * are packaged wrapped in one directory named after the skill (e.g.
+ * `pdf/SKILL.md`, `pdf/scripts/...`); the extractor strips it so contents land
+ * directly in the skill's dir instead of a redundant nested `<skill>/<skill>/`
+ * level. A flat or multi-root archive yields `''`.
  */
-function archiveTopDir(listing: string): string {
+function archiveTopDir(names: string[]): string {
   let top: string | undefined;
   let nested = false;
-  for (const raw of listing.split('\n')) {
+  for (const raw of names) {
     // Drop `.` / empty segments so a `./pdf/...`-style listing (e.g. from
     // `tar -C dir .`) is treated the same as `pdf/...`.
     const parts = raw
@@ -195,9 +253,14 @@ function archiveTopDir(listing: string): string {
  * to `unzip`/`tar` — consistent with the rest of the toolset, which already
  * invokes `bash` and `rg`. Both `unzip` and `tar` must be available on `PATH`; a
  * missing binary surfaces as a clear error (see {@link runArchiveTool}). Refuses
- * any member that would escape `dest` (zip-slip / tar-slip), including
- * symlink/hardlink members: skill archives come from the API, but skills can be
- * third-party.
+ * any member that would escape `dest` (zip-slip / tar-slip): skill archives
+ * come from the API, but skills can be third-party. Members that are not a
+ * regular file or directory (symlink, hardlink, device, fifo) are excluded
+ * from extraction rather than rejected; an archive whose special members
+ * cannot be excluded reliably is refused (see {@link classifyArchiveListing}).
+ * `tar` matches exclusions unanchored, so a plain member sharing a special
+ * member's name may be dropped too. The staging tree is verified to hold only
+ * regular files and directories before anything is promoted into `dest`.
  *
  * The skill bundle's single wrapper directory is stripped: the archive is
  * extracted into a staging dir and the wrapper's contents are promoted into
@@ -215,6 +278,7 @@ export async function extractSkillArchive(resp: Response, dest: string): Promise
     fssync.createWriteStream(tmp),
   );
   const stage = path.join(path.dirname(dest), `.skill-stage-${process.pid}-${Date.now()}`);
+  const excludeFile = path.join(path.dirname(dest), `.skill-exclude-${process.pid}-${Date.now()}`);
   try {
     // Sniff the first bytes: zip archives start with "PK\x03\x04"; treat
     // anything else as a tar.* archive (`tar -xf` autodetects gzip/bzip2/xz).
@@ -224,23 +288,55 @@ export async function extractSkillArchive(resp: Response, dest: string): Promise
     const archiveCmd = isZip ? 'unzip' : 'tar';
     // List first, validate, then extract — `tar`/`unzip` will happily write a
     // `../` member (or follow a symlink member) outside `-C`/`-d` otherwise.
-    const listing = await runArchiveTool(archiveCmd, isZip ? ['-Z1', tmp] : ['-tf', tmp]);
-    assertSafeMemberNames(listing);
-    assertNoSpecialMembers(await runArchiveTool(archiveCmd, isZip ? ['-Z', tmp] : ['-tvf', tmp]));
-    const top = archiveTopDir(listing);
+    const names = await runArchiveTool(archiveCmd, isZip ? ['-Z1', tmp] : ['-tf', tmp]);
+    const typed = await runArchiveTool(archiveCmd, isZip ? ['-Z', '--h', '--t', tmp] : ['-tvf', tmp]);
+    const { plain, special } = classifyArchiveListing(archiveCmd, names, typed);
+    assertSafeMemberNames([...plain, ...special]);
+    const top = archiveTopDir(plain);
     await fs.mkdir(stage, { recursive: true, mode: DIR_CREATE_MODE });
-    await runArchiveTool(archiveCmd, isZip ? ['-oq', tmp, '-d', stage] : ['-xf', tmp, '-C', stage]);
+    // `unzip` exits non-zero when every member is excluded, so only run the
+    // extractor when there is something to extract.
+    if (plain.length > 0) {
+      await runArchiveTool(archiveCmd, await extractArgs(archiveCmd, tmp, stage, special, excludeFile));
+    }
+    await assertOnlyPlainEntries(stage);
     // Promote the wrapper's contents (or the staged tree itself, if the
     // archive wasn't wrapped) into the already-created empty `dest`. `stage`
     // is a sibling of `dest`, so each rename stays on one filesystem.
     const srcRoot = top ? path.join(stage, top) : stage;
-    for (const entry of await fs.readdir(srcRoot)) {
+    const entries = await fs.readdir(srcRoot).catch((e: unknown) => {
+      throw errnoCode(e) === 'ENOENT' ? new AnthropicError(INCONSISTENT_LISTING) : e;
+    });
+    for (const entry of entries) {
       await fs.rename(path.join(srcRoot, entry), path.join(dest, entry));
     }
   } finally {
     await fs.rm(tmp, { force: true });
+    await fs.rm(excludeFile, { force: true });
     await fs.rm(stage, { recursive: true, force: true });
   }
+}
+
+/**
+ * Arguments that extract `archive` into `stage` while excluding every member
+ * in `special`. Names are glob-escaped because both CLIs treat exclusions as
+ * patterns; `tar` reads them from `excludeFile`, `unzip` takes them after
+ * `-x`, which must follow `-d` so no pattern is parsed as an option.
+ */
+async function extractArgs(
+  cmd: 'unzip' | 'tar',
+  archive: string,
+  stage: string,
+  special: string[],
+  excludeFile: string,
+): Promise<string[]> {
+  const patterns = special.map((name) => name.replace(/[*?[]/g, '\\$&'));
+  if (cmd === 'unzip') {
+    return ['-oq', archive, '-d', stage, ...(patterns.length > 0 ? ['-x', ...patterns] : [])];
+  }
+  if (patterns.length === 0) return ['-xf', archive, '-C', stage];
+  await fs.writeFile(excludeFile, patterns.join('\n') + '\n', { flag: 'wx', mode: 0o600 });
+  return ['-xf', archive, '-C', stage, '-X', excludeFile];
 }
 
 /** Read the first `n` bytes of `file`. */

--- a/tests/lib/environments/poller-iter.test.ts
+++ b/tests/lib/environments/poller-iter.test.ts
@@ -27,6 +27,7 @@ function makeFakeClient(opts: {
 }) {
   const calls: RecordedCall[] = [];
   const withOptionsCalls: Array<Record<string, unknown>> = [];
+  const warnings: string[] = [];
   let pollIdx = 0;
   let ackIdx = 0;
   let stopIdx = 0;
@@ -35,6 +36,8 @@ function makeFakeClient(opts: {
     // them onto the sub-client; provide a minimal shape so the util doesn't
     // throw on the fake.
     _options: { defaultHeaders: undefined },
+    logLevel: 'warn',
+    logger: { error: () => {}, warn: (msg: string) => warnings.push(msg), info: () => {}, debug: () => {} },
     withOptions: (options: Record<string, unknown>) => {
       withOptionsCalls.push(options);
       return fake;
@@ -65,7 +68,11 @@ function makeFakeClient(opts: {
       },
     },
   };
-  return { client: fake as never, calls, withOptionsCalls };
+  return { client: fake as never, calls, withOptionsCalls, warnings };
+}
+
+function apiError(status: number): APIError {
+  return Object.assign(Object.create(APIError.prototype) as APIError, { status });
 }
 
 function makeWork(id = 'work_1', dataType = 'session'): Record<string, unknown> {
@@ -165,34 +172,79 @@ describe('WorkPoller', () => {
     expect(calls.some((c) => c.method === 'stop')).toBe(true);
   });
 
-  test('backs off on poll errors using setTimeout-based delay', async () => {
-    const err = Object.assign(Object.create(APIError.prototype) as APIError, { status: 503 });
-    const work = makeWork();
+  for (const status of [503, 409]) {
+    test(`backs off on a ${status} poll error using setTimeout-based delay, then yields the next item`, async () => {
+      const work = makeWork();
+      const { client, calls } = makeFakeClient({
+        poll: [
+          { type: 'throw', err: apiError(status) },
+          { type: 'work', value: work },
+        ],
+      });
+
+      const iter = new WorkPoller({
+        client,
+        environmentId: 'env_1',
+        environmentKey: 'env_key',
+      });
+
+      const items: string[] = [];
+      const consumer = (async () => {
+        for await (const w of iter) {
+          items.push(w.id);
+          iter.abort();
+          break;
+        }
+      })();
+      // Drive past the initial 1s backoff window.
+      await jest.advanceTimersByTimeAsync(2_000);
+      await consumer;
+
+      expect(calls.filter((c) => c.method === 'poll').length).toBe(2);
+      expect(items).toEqual(['work_1']);
+    });
+  }
+
+  test('a 401 poll error is permanent and ends iteration with the error', async () => {
+    const err = apiError(401);
     const { client, calls } = makeFakeClient({
       poll: [
         { type: 'throw', err },
-        { type: 'work', value: work },
+        { type: 'work', value: makeWork() },
       ],
     });
 
-    const iter = new WorkPoller({
-      client,
-      environmentId: 'env_1',
-      environmentKey: 'env_key',
+    const iter = new WorkPoller({ client, environmentId: 'env_1', environmentKey: 'env_key' });
+    const consumer = (async () => {
+      for await (const _ of iter) {
+        // unreachable
+      }
+    })();
+    const outcome = expect(consumer).rejects.toBe(err);
+    await jest.advanceTimersByTimeAsync(5_000);
+    await outcome;
+
+    expect(calls.filter((c) => c.method === 'poll').length).toBe(1);
+  });
+
+  test('a 409 from the post-handler stop means already stopped and is not logged', async () => {
+    const { client, calls, warnings } = makeFakeClient({
+      poll: [{ type: 'work', value: makeWork() }],
+      stop: [{ type: 'throw', err: apiError(409) }],
     });
 
+    const iter = new WorkPoller({ client, environmentId: 'env_1', environmentKey: 'env_key' });
     const consumer = (async () => {
       for await (const _ of iter) {
         iter.abort();
         break;
       }
     })();
-    // Drive past the initial 1s backoff window.
-    await jest.advanceTimersByTimeAsync(2_000);
+    await jest.advanceTimersByTimeAsync(5_000);
     await consumer;
 
-    const polls = calls.filter((c) => c.method === 'poll').length;
-    expect(polls).toBe(2);
+    expect(calls.some((c) => c.method === 'stop')).toBe(true);
+    expect(warnings).not.toContain('stop failed');
   });
 
   test('honors externally provided AbortSignal', async () => {

--- a/tests/lib/environments/poller.test.ts
+++ b/tests/lib/environments/poller.test.ts
@@ -1,4 +1,4 @@
-import { backoff, jitter, isStatus, is4xx } from '@anthropic-ai/sdk/lib/environments';
+import { backoff, jitter, isStatus, is4xx, isFatal4xx } from '@anthropic-ai/sdk/lib/environments';
 import { APIError } from '@anthropic-ai/sdk/core/error';
 
 describe('backoff', () => {
@@ -61,6 +61,31 @@ describe('isStatus / is4xx', () => {
     test(tc.description, () => {
       expect(isStatus(tc.err, tc.status)).toBe(tc.wantIs);
       expect(is4xx(tc.err)).toBe(tc.want4xx);
+    });
+  }
+});
+
+describe('isFatal4xx', () => {
+  function makeErr(status: number): APIError {
+    return Object.assign(Object.create(APIError.prototype) as APIError, { status });
+  }
+
+  const cases: { description: string; err: unknown; want: boolean }[] = [
+    { description: '409 is retried like the core client does, not fatal', err: makeErr(409), want: false },
+    { description: '408 request timeout is not fatal', err: makeErr(408), want: false },
+    { description: '429 rate limit is not fatal', err: makeErr(429), want: false },
+    { description: '400 stays fatal', err: makeErr(400), want: true },
+    { description: '401 bad credential stays fatal', err: makeErr(401), want: true },
+    { description: '403 stays fatal', err: makeErr(403), want: true },
+    { description: '404 missing environment stays fatal', err: makeErr(404), want: true },
+    { description: '412 lease reclaimed stays fatal', err: makeErr(412), want: true },
+    { description: '422 stays fatal', err: makeErr(422), want: true },
+    { description: 'a 5xx is not a 4xx at all', err: makeErr(500), want: false },
+    { description: 'a non-API error is never classified as fatal 4xx', err: new Error('boom'), want: false },
+  ];
+  for (const tc of cases) {
+    test(tc.description, () => {
+      expect(isFatal4xx(tc.err)).toBe(tc.want);
     });
   }
 });

--- a/tests/lib/environments/worker.test.ts
+++ b/tests/lib/environments/worker.test.ts
@@ -1,5 +1,6 @@
 import { EnvironmentWorker } from '@anthropic-ai/sdk/lib/environments';
 import type { BetaRunnableTool } from '@anthropic-ai/sdk/lib/tools/BetaRunnableTool';
+import { APIError } from '@anthropic-ai/sdk/core/error';
 
 // =====
 // Test fakes
@@ -21,9 +22,22 @@ interface WorkerCalls {
   withOptions: Array<Record<string, unknown>>;
   // The `options` (last) argument captured per control-plane / session method.
   opts: Record<string, unknown[]>;
+  // `[level, message]` for every warn/error the worker logged.
+  logs: Array<[string, string]>;
 }
 
-function makeFake(opts: { sessionStream: AnyEvent[] }) {
+type HeartbeatResponse = {
+  last_heartbeat: string;
+  ttl_seconds: number;
+  state: string;
+  lease_extended: boolean;
+};
+
+function makeFake(opts: {
+  sessionStream: AnyEvent[];
+  /** Script the lease heartbeat per call (1-based); defaults to a healthy 60 s lease. */
+  heartbeat?: (call: number, options?: { signal?: AbortSignal }) => Promise<HeartbeatResponse>;
+}) {
   const calls: WorkerCalls = {
     poll: 0,
     ack: 0,
@@ -33,6 +47,7 @@ function makeFake(opts: { sessionStream: AnyEvent[] }) {
     retrieve: 0,
     withOptions: [],
     opts: { poll: [], ack: [], heartbeat: [], stop: [], send: [], stream: [], list: [] },
+    logs: [],
   };
   const externalAbort = new AbortController();
 
@@ -49,6 +64,13 @@ function makeFake(opts: { sessionStream: AnyEvent[] }) {
     // helper-telemetry default header. The fake records each `withOptions`
     // override and reuses itself so the rest of the surface stays wired up.
     _options: { defaultHeaders: undefined },
+    logLevel: 'warn',
+    logger: {
+      error: (msg: string) => calls.logs.push(['error', msg]),
+      warn: (msg: string) => calls.logs.push(['warn', msg]),
+      info: () => {},
+      debug: () => {},
+    },
     withOptions: (options: Record<string, unknown>) => {
       calls.withOptions.push(options);
       return fake;
@@ -69,9 +91,10 @@ function makeFake(opts: { sessionStream: AnyEvent[] }) {
             calls.opts['ack']!.push(options);
             return Promise.resolve(work);
           },
-          heartbeat: (_workId: string, _params: unknown, options?: unknown) => {
+          heartbeat: (_workId: string, _params: unknown, options?: { signal?: AbortSignal }) => {
             calls.heartbeat++;
             calls.opts['heartbeat']!.push(options);
+            if (opts.heartbeat) return opts.heartbeat(calls.heartbeat, options);
             return Promise.resolve({
               last_heartbeat: `hb_${calls.heartbeat}`,
               ttl_seconds: 60,
@@ -266,5 +289,74 @@ describe('EnvironmentWorker', () => {
     } finally {
       if (saved !== undefined) process.env['ANTHROPIC_ENVIRONMENT_KEY'] = saved;
     }
+  });
+
+  describe('lease heartbeat bounds', () => {
+    const apiError = (status: number): APIError =>
+      Object.assign(Object.create(APIError.prototype) as APIError, { status });
+    const healthy = (call: number, ttlSeconds: number): Promise<HeartbeatResponse> =>
+      Promise.resolve({
+        last_heartbeat: `hb_${call}`,
+        ttl_seconds: ttlSeconds,
+        state: 'running',
+        lease_extended: true,
+      });
+    /** A heartbeat call that never answers; it settles only when the worker gives up on it. */
+    const hang = (options?: { signal?: AbortSignal }): Promise<HeartbeatResponse> =>
+      new Promise((_, reject) => {
+        const signal = options?.signal;
+        if (!signal) return;
+        if (signal.aborted) return reject(signal.reason);
+        signal.addEventListener('abort', () => reject(signal.reason), { once: true });
+      });
+
+    // The session stream never terminates on its own in these tests, so the
+    // run only ends when the heartbeat loop aborts the session.
+    async function runOneSession(
+      heartbeat: (call: number, options?: { signal?: AbortSignal }) => Promise<HeartbeatResponse>,
+    ): Promise<{ calls: WorkerCalls; elapsedMs: number }> {
+      const { client, calls, signal } = makeFake({ sessionStream: [], heartbeat });
+      const started = Date.now();
+      await new EnvironmentWorker({
+        client,
+        environmentId: 'env_1',
+        environmentKey: 'env_key',
+        tools: [],
+        workdir: '/tmp',
+        maxIdleMs: 0,
+        signal,
+      }).run();
+      return { calls, elapsedMs: Date.now() - started };
+    }
+
+    test('a 409 is retried, and the session is given up once the lease ttl passes without a successful beat', async () => {
+      const { calls, elapsedMs } = await runOneSession((call) =>
+        call === 1 ? healthy(call, 2) : Promise.reject(apiError(409)),
+      );
+      expect(calls.heartbeat).toBeGreaterThanOrEqual(3);
+      expect(calls.logs).not.toContainEqual(['error', 'permanent heartbeat failure']);
+      expect(calls.logs).toContainEqual(['warn', 'transient heartbeat failure']);
+      expect(calls.logs).toContainEqual(['error', 'lease assumed lost: no successful heartbeat in ttl']);
+      expect(calls.stop.some((s) => s.force === true)).toBe(true);
+      expect(elapsedMs).toBeLessThan(8_000);
+    }, 10_000);
+
+    test('a heartbeat call that never answers is cut off each interval and the stale lease ends the session', async () => {
+      const { calls, elapsedMs } = await runOneSession((call, options) =>
+        call === 1 ? healthy(call, 1) : hang(options),
+      );
+      expect(calls.heartbeat).toBeGreaterThanOrEqual(2);
+      expect(calls.logs).toContainEqual(['error', 'lease assumed lost: no successful heartbeat in ttl']);
+      expect(calls.stop.some((s) => s.force === true)).toBe(true);
+      expect(elapsedMs).toBeLessThan(8_000);
+    }, 10_000);
+
+    test('a 401 is permanent: the session is cancelled on the first failure', async () => {
+      const { calls, elapsedMs } = await runOneSession(() => Promise.reject(apiError(401)));
+      expect(calls.heartbeat).toBe(1);
+      expect(calls.logs).toContainEqual(['error', 'permanent heartbeat failure']);
+      expect(calls.stop.some((s) => s.force === true)).toBe(true);
+      expect(elapsedMs).toBeLessThan(2_000);
+    }, 10_000);
   });
 });

--- a/tests/tools/agent-toolset.test.ts
+++ b/tests/tools/agent-toolset.test.ts
@@ -15,35 +15,130 @@ import {
   type AgentToolContext,
 } from '@anthropic-ai/sdk/tools/agent-toolset/node';
 import type { BetaRunnableTool } from '@anthropic-ai/sdk/lib/tools/BetaRunnableTool';
+import { ToolError } from '@anthropic-ai/sdk/lib/tools/ToolError';
 
 function tmpdir(): string {
   return fs.mkdtempSync(path.join(os.tmpdir(), 'runner-test-'));
 }
 
 const testPosix = process.platform === 'win32' ? test.skip : test;
+const describePosix = process.platform === 'win32' ? describe.skip : describe;
 
-// F1 / PATH-13: a cycle of dangling symlinks (which `realpath` cannot resolve)
-// must terminate at the canonicalize hop cap, not spin forever.
-(process.platform === 'win32' ? describe.skip : describe)('canonicalize symlink-loop bound', () => {
+// F1 / PATH-13: a cycle of symlinks (which `realpath` cannot resolve) must be
+// rejected at resolve time — never spin, never fall back to the unresolved
+// path, and never let a lexical `..` after the loop reach an outside file.
+describePosix('canonicalize symlink-loop bound', () => {
   let dir: string;
+  let outside: string;
+  const FIXTURE = ['L', 'evil_link', 'loop_a', 'loop_b', 'self'];
   beforeEach(() => {
     dir = tmpdir();
+    outside = tmpdir();
+    fs.writeFileSync(path.join(outside, 'secret.txt'), 'SECRET');
     fs.symlinkSync(path.join(dir, 'loop_b'), path.join(dir, 'loop_a'));
     fs.symlinkSync(path.join(dir, 'loop_a'), path.join(dir, 'loop_b'));
+    fs.symlinkSync('self', path.join(dir, 'self'));
+    fs.symlinkSync(path.join(outside, 'secret.txt'), path.join(dir, 'evil_link'));
+    fs.symlinkSync('loop_a/../evil_link', path.join(dir, 'L'));
   });
-  afterEach(() => fs.rmSync(dir, { recursive: true, force: true }));
+  afterEach(() => {
+    fs.rmSync(dir, { recursive: true, force: true });
+    fs.rmSync(outside, { recursive: true, force: true });
+  });
 
-  test('resolvePath on a symlink loop throws instead of spinning', async () => {
-    await expect(resolvePath({ workdir: dir }, 'loop_a')).rejects.toThrow(
-      /too many levels of symbolic links/,
-    );
-  }, 2000);
+  for (const p of ['loop_a', 'loop_a/child.txt', 'self', 'self/x']) {
+    test(`resolvePath(${JSON.stringify(p)}) rejects with the loop error and no host path`, async () => {
+      const err = await resolvePath({ workdir: dir }, p).catch((e: unknown) => e);
+      expect(err).toBeInstanceOf(ToolError);
+      expect((err as Error).message).toBe(`path ${JSON.stringify(p)}: too many levels of symbolic links`);
+      expect((err as Error).message).not.toContain(dir);
+    }, 2000);
+  }
 
-  test('resolvePath on a path under a symlink loop also throws', async () => {
-    await expect(resolvePath({ workdir: dir }, 'loop_a/child.txt')).rejects.toThrow(
-      /too many levels of symbolic links/,
+  test('a lexical .. after a looping component is collapsed first, so the escape is still caught', async () => {
+    await expect(resolvePath({ workdir: dir }, 'loop_a/../evil_link')).rejects.toThrow(/escapes workdir/);
+    await expect(resolvePath({ workdir: dir }, 'self/../evil_link')).rejects.toThrow(/escapes workdir/);
+    await expect(resolvePath({ workdir: dir }, 'L')).rejects.toThrow(
+      /too many levels of symbolic links|escapes workdir/,
     );
-  }, 2000);
+  });
+
+  test('read of a looping path reports the loop and never returns outside content', async () => {
+    const read = betaReadTool({ workdir: dir });
+    await expect(read.run({ file_path: 'loop_a' })).rejects.toThrow(
+      new ToolError('path "loop_a": too many levels of symbolic links'),
+    );
+    for (const p of ['loop_a/../evil_link', 'L']) {
+      const err = await Promise.resolve(read.run({ file_path: p })).then(
+        (out) => new Error(`unexpectedly read ${String(out).length} bytes`),
+        (e: unknown) => e,
+      );
+      expect(err).toBeInstanceOf(ToolError);
+      expect((err as Error).message).not.toContain('SECRET');
+    }
+  });
+
+  test('write under a looping path is rejected before anything is created', async () => {
+    await expect(
+      betaWriteTool({ workdir: dir }).run({ file_path: 'loop_a/child.txt', content: 'x' }),
+    ).rejects.toThrow(/too many levels of symbolic links/);
+    expect(fs.readdirSync(dir).sort()).toEqual(FIXTURE);
+  });
+
+  test('glob silently drops looping entries and still lists regular files', async () => {
+    fs.writeFileSync(path.join(dir, 'ok.txt'), 'ok');
+    const out = await betaGlobTool({ workdir: dir }).run({ pattern: '*' });
+    expect(String(out).split('\n')).toEqual([path.join(dir, 'ok.txt')]);
+  });
+});
+
+describePosix('resolvePath symlink regressions', () => {
+  let dir: string;
+  let outside: string;
+  beforeEach(() => {
+    dir = tmpdir();
+    outside = tmpdir();
+    fs.writeFileSync(path.join(outside, 'secret.txt'), 'SECRET');
+  });
+  afterEach(() => {
+    fs.rmSync(dir, { recursive: true, force: true });
+    fs.rmSync(outside, { recursive: true, force: true });
+  });
+
+  test('write through a dangling in-workdir symlink creates the target and its missing parents', async () => {
+    fs.symlinkSync(path.join(dir, 'newdir', 'f.txt'), path.join(dir, 'd'));
+    await betaWriteTool({ workdir: dir }).run({ file_path: 'd', content: 'via-link' });
+    expect(fs.readFileSync(path.join(dir, 'newdir', 'f.txt'), 'utf8')).toBe('via-link');
+  });
+
+  test('read follows a short in-workdir symlink chain to its final target', async () => {
+    fs.writeFileSync(path.join(dir, 'real.txt'), 'chained');
+    fs.symlinkSync('real.txt', path.join(dir, 'c2'));
+    fs.symlinkSync('c2', path.join(dir, 'c1'));
+    fs.symlinkSync('c1', path.join(dir, 'c0'));
+    expect(await betaReadTool({ workdir: dir }).run({ file_path: 'c0' })).toBe('chained');
+  });
+
+  test('live and dangling symlinks pointing outside the workdir are both rejected', async () => {
+    fs.symlinkSync(path.join(outside, 'secret.txt'), path.join(dir, 'out'));
+    fs.symlinkSync(path.join(outside, 'nope'), path.join(dir, 'dangle_out'));
+    await expect(resolvePath({ workdir: dir }, 'out')).rejects.toThrow(/escapes workdir/);
+    await expect(resolvePath({ workdir: dir }, 'dangle_out')).rejects.toThrow(/escapes workdir/);
+  });
+
+  test('an unreadable directory is reported as permission denied without the host path', async () => {
+    if (process.getuid?.() === 0) return;
+    fs.mkdirSync(path.join(dir, 'noperm'), { mode: 0o000 });
+    try {
+      const err = await Promise.resolve(betaReadTool({ workdir: dir }).run({ file_path: 'noperm/x' })).catch(
+        (e: unknown) => e,
+      );
+      expect(err).toBeInstanceOf(ToolError);
+      expect((err as Error).message).toBe('path "noperm/x": permission denied');
+    } finally {
+      fs.chmodSync(path.join(dir, 'noperm'), 0o755);
+    }
+  });
 });
 
 describe('betaAgentToolset20260401', () => {
@@ -140,10 +235,37 @@ describe('fs tools (read/write/edit)', () => {
     expect(out).toBe('hello');
   });
 
+  test('write under many not-yet-existing directories succeeds because only symlink hops are capped', async () => {
+    const rel = path.join(...Array.from({ length: 50 }, (_, i) => `d${i}`), 'f.txt');
+    await betaWriteTool(env).run({ file_path: rel, content: 'deep' });
+    expect(fs.readFileSync(path.join(dir, rel), 'utf8')).toBe('deep');
+  });
+
   test('read with view_range returns the 1-indexed inclusive line slice', async () => {
     fs.writeFileSync(path.join(dir, 'f.txt'), 'a\nb\nc\nd\n');
     const out = await betaReadTool(env).run({ file_path: 'f.txt', view_range: [2, 3] });
     expect(out).toBe('b\nc');
+  });
+
+  const viewRangeCases: { description: string; view_range: number[]; want: string }[] = [
+    { description: 'an inverted range yields an empty result, not an error', view_range: [3, 1], want: '' },
+    { description: 'an empty range reads the whole file', view_range: [], want: 'line1\nline2\nline3' },
+    { description: 'a single-line range', view_range: [2, 2], want: 'line2' },
+    { description: 'a non-positive end line reads to EOF', view_range: [2, 0], want: 'line2\nline3' },
+    { description: 'a start line past EOF yields an empty result', view_range: [10, 12], want: '' },
+  ];
+  for (const tc of viewRangeCases) {
+    test(`read view_range ${JSON.stringify(tc.view_range)}: ${tc.description}`, async () => {
+      fs.writeFileSync(path.join(dir, 'a.txt'), 'line1\nline2\nline3');
+      expect(await betaReadTool(env).run({ file_path: 'a.txt', view_range: tc.view_range })).toBe(tc.want);
+    });
+  }
+
+  test('read view_range with the wrong arity is rejected', async () => {
+    fs.writeFileSync(path.join(dir, 'a.txt'), 'line1\nline2\nline3');
+    await expect(betaReadTool(env).run({ file_path: 'a.txt', view_range: [2] })).rejects.toThrow(
+      'read: view_range must be [start_line, end_line]',
+    );
   });
 
   test('read of a missing file throws ToolError so the dispatcher reports is_error', async () => {

--- a/tests/tools/skills.test.ts
+++ b/tests/tools/skills.test.ts
@@ -2,20 +2,153 @@ import * as fs from 'node:fs';
 import * as fsp from 'node:fs/promises';
 import * as path from 'node:path';
 import * as os from 'node:os';
+import * as zlib from 'node:zlib';
 import { execFileSync } from 'node:child_process';
 import { extractSkillArchive } from '@anthropic-ai/sdk/tools/agent-toolset/node';
+import { assertOnlyPlainEntries, classifyArchiveListing } from '@anthropic-ai/sdk/tools/agent-toolset/skills';
+
+const testPosix = process.platform === 'win32' ? test.skip : test;
+
+const S_IFLNK = 0o120000;
+const S_IFIFO = 0o010000;
+const S_IFREG = 0o100000;
+
+interface TarEntry {
+  name: string;
+  /** ustar typeflag: '0' file, '\0' old file, '1' hardlink, '2' symlink, '3' char, '5' dir, '6' fifo, '7' contiguous, 'g' pax global. */
+  type: string;
+  body?: string;
+  mode?: number;
+  linkname?: string;
+}
+
+/** Minimal ustar writer, enough to set any typeflag and linkname. */
+function makeTar(entries: TarEntry[]): Buffer {
+  const octal = (n: number, width: number) => n.toString(8).padStart(width - 1, '0') + '\0';
+  const blocks: Buffer[] = [];
+  for (const e of entries) {
+    const body = Buffer.from(e.body ?? '', 'utf8');
+    const h = Buffer.alloc(512, 0);
+    h.write(e.name, 0, 100, 'utf8');
+    h.write(octal(e.mode ?? 0o644, 8), 100, 8, 'ascii');
+    h.write(octal(0, 8), 108, 8, 'ascii');
+    h.write(octal(0, 8), 116, 8, 'ascii');
+    h.write(octal(body.length, 12), 124, 12, 'ascii');
+    h.write(octal(0, 12), 136, 12, 'ascii');
+    h.write('        ', 148, 8, 'ascii');
+    h.write(e.type, 156, 1, 'latin1');
+    h.write(e.linkname ?? '', 157, 100, 'utf8');
+    h.write('ustar\0' + '00', 257, 8, 'ascii');
+    if (e.type === '3' || e.type === '4') {
+      h.write(octal(1, 8), 329, 8, 'ascii');
+      h.write(octal(3, 8), 337, 8, 'ascii');
+    }
+    h.write(
+      octal(
+        [...h].reduce((a, b) => a + b, 0),
+        7,
+      ) + ' ',
+      148,
+      8,
+      'ascii',
+    );
+    blocks.push(h, body, Buffer.alloc((512 - (body.length % 512)) % 512, 0));
+  }
+  blocks.push(Buffer.alloc(1024, 0));
+  return Buffer.concat(blocks);
+}
+
+interface ZipEntry {
+  name: string;
+  body?: string;
+  /** `create_system`: 3 = Unix (mode bits in `externalAttr >> 16` are honoured), 0 = FAT. */
+  createSystem?: number;
+  externalAttr?: number;
+}
+
+/** Minimal stored-method zip writer, enough to set create_system and external_attr. */
+function makeZip(entries: ZipEntry[]): Buffer {
+  const locals: Buffer[] = [];
+  const centrals: Buffer[] = [];
+  let offset = 0;
+  for (const e of entries) {
+    const name = Buffer.from(e.name, 'utf8');
+    const body = Buffer.from(e.body ?? '', 'utf8');
+    const crc = zlib.crc32(body);
+    const local = Buffer.alloc(30, 0);
+    local.writeUInt32LE(0x04034b50, 0);
+    local.writeUInt16LE(10, 4);
+    local.writeUInt16LE(0x21, 12);
+    local.writeUInt32LE(crc, 14);
+    local.writeUInt32LE(body.length, 18);
+    local.writeUInt32LE(body.length, 22);
+    local.writeUInt16LE(name.length, 26);
+    locals.push(local, name, body);
+    const central = Buffer.alloc(46, 0);
+    central.writeUInt32LE(0x02014b50, 0);
+    central.writeUInt16LE(((e.createSystem ?? 3) << 8) | 30, 4);
+    central.writeUInt16LE(10, 6);
+    central.writeUInt16LE(0x21, 14);
+    central.writeUInt32LE(crc, 16);
+    central.writeUInt32LE(body.length, 20);
+    central.writeUInt32LE(body.length, 24);
+    central.writeUInt16LE(name.length, 28);
+    central.writeUInt32LE((e.externalAttr ?? (S_IFREG | 0o644) << 16) >>> 0, 38);
+    central.writeUInt32LE(offset, 42);
+    centrals.push(central, name);
+    offset += local.length + name.length + body.length;
+  }
+  const cd = Buffer.concat(centrals);
+  const end = Buffer.alloc(22, 0);
+  end.writeUInt32LE(0x06054b50, 0);
+  end.writeUInt16LE(entries.length, 8);
+  end.writeUInt16LE(entries.length, 10);
+  end.writeUInt32LE(cd.length, 12);
+  end.writeUInt32LE(offset, 16);
+  return Buffer.concat([...locals, cd, end]);
+}
+
+const zipSymlink = (name: string, target = '/etc/passwd'): ZipEntry => ({
+  name,
+  body: target,
+  createSystem: 3,
+  externalAttr: (S_IFLNK | 0o777) << 16,
+});
+
+/** Every entry under `root` as `[relative path, lstat type]`, sorted. */
+function tree(root: string): Array<[string, 'file' | 'dir' | 'other']> {
+  const out: Array<[string, 'file' | 'dir' | 'other']> = [];
+  const walk = (dir: string) => {
+    for (const d of fs.readdirSync(dir, { withFileTypes: true })) {
+      const rel = path.relative(root, path.join(dir, d.name));
+      out.push([
+        rel,
+        d.isFile() ? 'file'
+        : d.isDirectory() ? 'dir'
+        : 'other',
+      ]);
+      if (d.isDirectory()) walk(path.join(dir, d.name));
+    }
+  };
+  walk(root);
+  return out.sort(([a], [b]) => (a < b ? -1 : 1));
+}
 
 /**
  * Skill version archives are packaged wrapped in a single directory named
  * after the skill (e.g. `pdf/SKILL.md`). Extraction must strip that wrapper so
  * files land at `dest/SKILL.md`, not the doubled `dest/pdf/SKILL.md` the
- * agent's skill discovery does not find. It must also still refuse zip-slip.
+ * agent's skill discovery does not find. It must also still refuse zip-slip,
+ * and skip (never materialise) members that are not regular files or
+ * directories.
  */
 describe('extractSkillArchive', () => {
   let work: string;
+  let dest: string;
 
   beforeEach(() => {
     work = fs.mkdtempSync(path.join(os.tmpdir(), 'skilltest-'));
+    dest = path.join(work, 'skills', 'pdf');
   });
   afterEach(() => {
     fs.rmSync(work, { recursive: true, force: true });
@@ -44,9 +177,9 @@ describe('extractSkillArchive', () => {
     }
   }
 
-  async function extractInto(buf: Buffer, dest: string): Promise<void> {
-    await fsp.mkdir(dest, { recursive: true });
-    await extractSkillArchive(new Response(buf), dest);
+  async function extractInto(buf: Buffer, into: string): Promise<void> {
+    await fsp.mkdir(into, { recursive: true });
+    await extractSkillArchive(new Response(buf), into);
   }
 
   for (const kind of ['zip', 'targz'] as const) {
@@ -55,7 +188,6 @@ describe('extractSkillArchive', () => {
         'pdf/SKILL.md': '# PDF',
         'pdf/scripts/run.py': 'print(1)',
       });
-      const dest = path.join(work, 'skills', 'pdf');
       await extractInto(buf, dest);
 
       expect(fs.readFileSync(path.join(dest, 'SKILL.md'), 'utf8')).toBe('# PDF');
@@ -65,10 +197,10 @@ describe('extractSkillArchive', () => {
 
     test(`${kind}: flat archive (no wrapper) extracts unchanged`, async () => {
       const buf = pack(kind, { 'SKILL.md': '# flat', 'scripts/run.py': 'x' });
-      const dest = path.join(work, 'skills', 'flat');
-      await extractInto(buf, dest);
-      expect(fs.readFileSync(path.join(dest, 'SKILL.md'), 'utf8')).toBe('# flat');
-      expect(fs.readFileSync(path.join(dest, 'scripts', 'run.py'), 'utf8')).toBe('x');
+      const flat = path.join(work, 'skills', 'flat');
+      await extractInto(buf, flat);
+      expect(fs.readFileSync(path.join(flat, 'SKILL.md'), 'utf8')).toBe('# flat');
+      expect(fs.readFileSync(path.join(flat, 'scripts', 'run.py'), 'utf8')).toBe('x');
     });
   }
 
@@ -81,9 +213,9 @@ describe('extractSkillArchive', () => {
       // Rewrite the entry name to a traversal path via zipnote.
       execFileSync('zipnote', ['-w', archive], { input: '@ escape.txt\n@=../escape.txt\n' });
 
-      const dest = path.join(work, 'skills', 'x');
-      await fsp.mkdir(dest, { recursive: true });
-      await expect(extractSkillArchive(new Response(fs.readFileSync(archive)), dest)).rejects.toThrow(
+      const x = path.join(work, 'skills', 'x');
+      await fsp.mkdir(x, { recursive: true });
+      await expect(extractSkillArchive(new Response(fs.readFileSync(archive)), x)).rejects.toThrow(
         /unsafe archive member/,
       );
       expect(fs.existsSync(path.join(work, 'skills', 'escape.txt'))).toBe(false);
@@ -91,5 +223,275 @@ describe('extractSkillArchive', () => {
     } finally {
       fs.rmSync(src, { recursive: true, force: true });
     }
+  });
+
+  test('tar: symlink, hardlink, fifo and device members are skipped and everything else extracts', async () => {
+    const buf = makeTar([
+      { name: 'pdf/', type: '5', mode: 0o755 },
+      { name: 'pdf/SKILL.md', type: '0', body: '# PDF' },
+      { name: 'pdf/scripts/run.sh', type: '0', mode: 0o755, body: 'echo hi' },
+      { name: 'pdf/old', type: '\0', body: 'v7' },
+      { name: 'pdf/abs', type: '2', linkname: '/etc/passwd' },
+      { name: 'pdf/rel', type: '2', linkname: 'SKILL.md' },
+      { name: 'pdf/hl', type: '1', linkname: 'pdf/SKILL.md' },
+      { name: 'pdf/fifo', type: '6' },
+      { name: 'pdf/dev', type: '3' },
+    ]);
+    await extractInto(buf, dest);
+
+    expect(fs.readFileSync(path.join(dest, 'SKILL.md'), 'utf8')).toBe('# PDF');
+    expect(fs.readFileSync(path.join(dest, 'old'), 'utf8')).toBe('v7');
+    expect(fs.statSync(path.join(dest, 'scripts', 'run.sh')).mode & 0o777).toBe(0o755);
+    for (const skipped of ['abs', 'rel', 'hl', 'fifo', 'dev', 'pdf']) {
+      expect(() => fs.lstatSync(path.join(dest, skipped))).toThrow(/ENOENT/);
+    }
+    expect(tree(work)).toEqual([
+      ['skills', 'dir'],
+      ['skills/pdf', 'dir'],
+      ['skills/pdf/SKILL.md', 'file'],
+      ['skills/pdf/old', 'file'],
+      ['skills/pdf/scripts', 'dir'],
+      ['skills/pdf/scripts/run.sh', 'file'],
+    ]);
+  });
+
+  test('zip: a Unix-host symlink or fifo entry is skipped, not written out as a file', async () => {
+    const buf = makeZip([
+      { name: 'pdf/SKILL.md', body: '# PDF' },
+      zipSymlink('pdf/lnk'),
+      { name: 'pdf/fifo', createSystem: 3, externalAttr: (S_IFIFO | 0o644) << 16 },
+    ]);
+    await extractInto(buf, dest);
+    expect(fs.readFileSync(path.join(dest, 'SKILL.md'), 'utf8')).toBe('# PDF');
+    expect(() => fs.lstatSync(path.join(dest, 'lnk'))).toThrow(/ENOENT/);
+    expect(() => fs.lstatSync(path.join(dest, 'fifo'))).toThrow(/ENOENT/);
+  });
+
+  test('zip: symlink type bits on a non-Unix-host entry are data, so the entry is a regular file', async () => {
+    const buf = makeZip([
+      { name: 'pdf/SKILL.md', body: '# PDF' },
+      { ...zipSymlink('pdf/lnk'), createSystem: 0 },
+    ]);
+    await extractInto(buf, dest);
+    expect(fs.lstatSync(path.join(dest, 'lnk')).isFile()).toBe(true);
+    expect(fs.readFileSync(path.join(dest, 'lnk'), 'utf8')).toBe('/etc/passwd');
+  });
+
+  test('zip: entries with no Unix type bits still extract as files', async () => {
+    const buf = makeZip([
+      { name: 'pdf/SKILL.md', body: '# PDF', createSystem: 3, externalAttr: 0o755 << 16 },
+      { name: 'pdf/notes', body: 'n', createSystem: 3, externalAttr: 0o600 << 16 },
+    ]);
+    await extractInto(buf, dest);
+    expect(fs.readFileSync(path.join(dest, 'SKILL.md'), 'utf8')).toBe('# PDF');
+    expect(fs.readFileSync(path.join(dest, 'notes'), 'utf8')).toBe('n');
+  });
+
+  test('tar: a top-level symlink beside the wrapper does not defeat wrapper stripping', async () => {
+    const buf = makeTar([
+      { name: 'link', type: '2', linkname: '/tmp' },
+      { name: 'pdf/SKILL.md', type: '0', body: '# PDF' },
+    ]);
+    await extractInto(buf, dest);
+    expect(fs.readFileSync(path.join(dest, 'SKILL.md'), 'utf8')).toBe('# PDF');
+    expect(fs.existsSync(path.join(dest, 'pdf'))).toBe(false);
+    expect(() => fs.lstatSync(path.join(dest, 'link'))).toThrow(/ENOENT/);
+  });
+
+  test('tar: a PAX global header (git archive) leaves no file behind and the wrapper is stripped', async () => {
+    const buf = makeTar([
+      { name: 'pax_global_header', type: 'g', body: '52 comment=0123456789012345678901234567890123456789\n' },
+      { name: 'pdf/SKILL.md', type: '0', body: '# PDF' },
+    ]);
+    await extractInto(buf, dest);
+    expect(tree(dest)).toEqual([['SKILL.md', 'file']]);
+  });
+
+  test('tar: a skipped symlink with an unsafe name still fails the whole archive', async () => {
+    const buf = makeTar([
+      { name: '../x', type: '2', linkname: '/tmp' },
+      { name: 'pdf/SKILL.md', type: '0', body: '# PDF' },
+    ]);
+    await expect(extractInto(buf, dest)).rejects.toThrow(/unsafe archive member/);
+    expect(tree(dest)).toEqual([]);
+    expect(fs.existsSync(path.join(work, 'skills', 'x'))).toBe(false);
+  });
+
+  for (const kind of ['tar', 'zip'] as const) {
+    test(`${kind}: glob characters in a skipped member's name are matched literally`, async () => {
+      const buf =
+        kind === 'tar' ?
+          makeTar([
+            { name: 'pdf/SKILL.md', type: '0', body: '# PDF' },
+            { name: 'pdf/a*', type: '2', linkname: '/tmp' },
+            { name: 'pdf/abc', type: '0', body: 'abc' },
+          ])
+        : makeZip([
+            { name: 'pdf/SKILL.md', body: '# PDF' },
+            zipSymlink('pdf/a*'),
+            { name: 'pdf/abc', body: 'abc' },
+          ]);
+      await extractInto(buf, dest);
+      expect(fs.readFileSync(path.join(dest, 'abc'), 'utf8')).toBe('abc');
+      expect(() => fs.lstatSync(path.join(dest, 'a*'))).toThrow(/ENOENT/);
+    });
+
+    test(`${kind}: an archive holding only a special member extracts to an empty directory`, async () => {
+      const buf =
+        kind === 'tar' ?
+          makeTar([{ name: 'pdf/lnk', type: '2', linkname: '/etc/passwd' }])
+        : makeZip([zipSymlink('pdf/lnk')]);
+      await extractInto(buf, dest);
+      expect(tree(dest)).toEqual([]);
+    });
+  }
+
+  const unexcludable: Array<{ description: string; buf: () => Buffer }> = [
+    {
+      description: 'zip symlink whose name starts with a dash',
+      buf: () => makeZip([{ name: 'pdf/SKILL.md', body: '#' }, zipSymlink('-dX/evil')]),
+    },
+    {
+      description: 'zip symlink with a non-ASCII name',
+      buf: () => makeZip([{ name: 'pdf/SKILL.md', body: '#' }, zipSymlink('pdf/café')]),
+    },
+    {
+      description: 'zip symlink with a control character in its name',
+      buf: () => makeZip([{ name: 'pdf/SKILL.md', body: '#' }, zipSymlink('pdf/c\x01d')]),
+    },
+    {
+      description: 'tar symlink with a non-ASCII name',
+      buf: () =>
+        makeTar([
+          { name: 'pdf/SKILL.md', type: '0', body: '#' },
+          { name: 'pdf/café', type: '2', linkname: '/tmp' },
+        ]),
+    },
+    {
+      description: 'tar symlink with a control character in its name',
+      buf: () =>
+        makeTar([
+          { name: 'pdf/SKILL.md', type: '0', body: '#' },
+          { name: 'pdf/c\x01d', type: '2', linkname: '/tmp' },
+        ]),
+    },
+    {
+      description: 'tar symlink with a backslash in its name',
+      buf: () =>
+        makeTar([
+          { name: 'pdf/SKILL.md', type: '0', body: '#' },
+          { name: 'pdf/back\\slash', type: '2', linkname: '/tmp' },
+        ]),
+    },
+  ];
+  for (const tc of unexcludable) {
+    test(`refuses the archive when a special member cannot be excluded by name: ${tc.description}`, async () => {
+      await expect(extractInto(tc.buf(), dest)).rejects.toThrow(/cannot safely exclude member/);
+      expect(tree(dest)).toEqual([]);
+      expect(fs.existsSync(path.join(work, 'skills', 'X'))).toBe(false);
+      expect(tree(work).filter(([, type]) => type === 'other')).toEqual([]);
+    });
+  }
+
+  test('tar: over-exclusion of a name twin never leaves a symlink behind', async () => {
+    const buf = makeTar([
+      { name: 'SKILL.md', type: '2', linkname: '/etc/passwd' },
+      { name: 'pdf/SKILL.md', type: '0', body: '# PDF' },
+      { name: 'pdf/x', type: '0', body: 'x' },
+    ]);
+    await extractInto(buf, dest).catch((e: unknown) => {
+      expect(String(e)).toMatch(/listing is inconsistent/);
+    });
+    expect(tree(work).filter(([, type]) => type === 'other')).toEqual([]);
+    if (fs.existsSync(path.join(dest, 'SKILL.md'))) {
+      expect(fs.lstatSync(path.join(dest, 'SKILL.md')).isFile()).toBe(true);
+    }
+  });
+});
+
+describe('classifyArchiveListing', () => {
+  test('splits members by the typed listing and keeps zipinfo "?" rows as plain', () => {
+    const names = 'pdf/SKILL.md\npdf/lnk\npdf/nobits\npdf/sub/\npdf/fifo\n';
+    const typed = [
+      '-rw-r--r--  3.0 unx        5 b- stor 80-Jan-01 00:00 pdf/SKILL.md',
+      'lrwxrwxrwx  3.0 unx       11 b- stor 80-Jan-01 00:00 pdf/lnk',
+      '?rwxr-xr-x  3.0 unx        1 b- stor 80-Jan-01 00:00 pdf/nobits',
+      'drwxr-xr-x  3.0 unx        0 b- stor 80-Jan-01 00:00 pdf/sub/',
+      'prw-r--r--  3.0 unx        0 b- stor 80-Jan-01 00:00 pdf/fifo',
+      '',
+    ].join('\n');
+    expect(classifyArchiveListing('unzip', names, typed)).toEqual({
+      plain: ['pdf/SKILL.md', 'pdf/nobits', 'pdf/sub/'],
+      special: ['pdf/lnk', 'pdf/fifo'],
+    });
+  });
+
+  test('treats GNU tar contiguous files as plain and hardlinks as special', () => {
+    const names = 'pdf/cont\npdf/hl\n';
+    const typed =
+      'Crw-r--r-- 0/0 4 1970-01-01 00:00 pdf/cont\nhrw-r--r-- 0/0 0 1970-01-01 00:00 pdf/hl link to pdf/SKILL.md\n';
+    expect(classifyArchiveListing('tar', names, typed)).toEqual({ plain: ['pdf/cont'], special: ['pdf/hl'] });
+  });
+
+  test('refuses listings whose line counts differ', () => {
+    expect(() => classifyArchiveListing('tar', 'a\nb\n', '-rw a\n')).toThrow(/listing is inconsistent/);
+  });
+
+  const link = 'lrwxrwxrwx x';
+  const cases: Array<{ cmd: 'unzip' | 'tar'; name: string }> = [
+    { cmd: 'unzip', name: '-dX/evil' },
+    { cmd: 'unzip', name: 'pdf/c^Ad' },
+    { cmd: 'unzip', name: 'pdf/café' },
+    { cmd: 'unzip', name: 'pdf/#U00e9' },
+    { cmd: 'tar', name: 'pdf/café' },
+    { cmd: 'tar', name: 'pdf/c\\001d' },
+    { cmd: 'tar', name: 'pdf/back\\\\slash' },
+  ];
+  for (const tc of cases) {
+    test(`refuses a special member the CLI cannot exclude verbatim: ${tc.cmd} ${JSON.stringify(
+      tc.name,
+    )}`, () => {
+      expect(() => classifyArchiveListing(tc.cmd, `${tc.name}\n`, `${link}\n`)).toThrow(
+        /cannot safely exclude member/,
+      );
+    });
+  }
+
+  test('a leading dash only matters for unzip, and only on special members', () => {
+    expect(classifyArchiveListing('tar', '-x\n', `${link}\n`)).toEqual({ plain: [], special: ['-x'] });
+    expect(classifyArchiveListing('unzip', '-x\n', '-rw x\n')).toEqual({ plain: ['-x'], special: [] });
+  });
+});
+
+describe('assertOnlyPlainEntries', () => {
+  let root: string;
+  beforeEach(() => {
+    root = fs.mkdtempSync(path.join(os.tmpdir(), 'plain-'));
+    fs.mkdirSync(path.join(root, 'd'));
+    fs.writeFileSync(path.join(root, 'd', 'f'), 'x');
+  });
+  afterEach(() => {
+    fs.rmSync(root, { recursive: true, force: true });
+  });
+
+  test('accepts a tree of files and directories', async () => {
+    await expect(assertOnlyPlainEntries(root)).resolves.toBeUndefined();
+  });
+
+  testPosix('rejects a symlink to a directory without reading through it', async () => {
+    const target = fs.mkdtempSync(path.join(os.tmpdir(), 'plain-target-'));
+    fs.chmodSync(target, 0o000);
+    try {
+      fs.symlinkSync(target, path.join(root, 'd', 'link'), 'dir');
+      await expect(assertOnlyPlainEntries(root)).rejects.toThrow(/listing is inconsistent/);
+    } finally {
+      fs.chmodSync(target, 0o755);
+      fs.rmSync(target, { recursive: true, force: true });
+    }
+  });
+
+  testPosix('rejects a fifo', async () => {
+    execFileSync('mkfifo', [path.join(root, 'd', 'pipe')]);
+    await expect(assertOnlyPlainEntries(root)).rejects.toThrow(/listing is inconsistent/);
   });
 });


### PR DESCRIPTION
## Summary
Fix 'typicaly' -> 'typically' in packages/bedrock-sdk/README.md.

Rebased onto the current `next` to clear the merge conflict. The other typos from the original PR (README.md 'overriden', CONTRIBUTING.md em-dash in `pnpm link --global`, helpers.md import paths) have since been fixed upstream, so only the bedrock README change remains.