### PR TITLE
bug/proposal: infinitely hanging clients breaking bigger/complex sessions. Proposal: add Streaming Idle Timeout to Prevent Indefinite Hangs #867

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -199,6 +199,22 @@ export interface ClientOptions {
    * @unit milliseconds
    */
   timeout?: number | undefined;
+
+  /**
+   * The maximum amount of time (in milliseconds) to wait between SSE events during streaming.
+   * If no event is received within this period, the stream will be aborted with a
+   * `StreamIdleTimeoutError`.
+   *
+   * This is distinct from `timeout` which applies to the overall request. `idleTimeout`
+   * specifically detects stalled streams where the connection is alive but no data is flowing.
+   *
+   * Can be overridden per-request via `RequestOptions.idleTimeout`.
+   *
+   * @unit milliseconds
+   * @default undefined (no idle timeout)
+   */
+  idleTimeout?: number | undefined;
+
   /**
    * Additional `RequestInit` options to be passed to `fetch` calls.
    * Properties will be overridden by per-request `fetchOptions`.
@@ -270,6 +286,7 @@ export class BaseAnthropic {
   baseURL: string;
   maxRetries: number;
   timeout: number;
+  idleTimeout: number | undefined;
   logger: Logger;
   logLevel: LogLevel | undefined;
   fetchOptions: MergedRequestInit | undefined;
@@ -314,6 +331,7 @@ export class BaseAnthropic {
 
     this.baseURL = options.baseURL!;
     this.timeout = options.timeout ?? BaseAnthropic.DEFAULT_TIMEOUT /* 10 minutes */;
+    this.idleTimeout = options.idleTimeout;
     this.logger = options.logger ?? console;
     const defaultLogLevel = 'warn';
     // Set default logLevel early so that we can log a warning in parseLogLevel.
@@ -342,6 +360,7 @@ export class BaseAnthropic {
       baseURL: this.baseURL,
       maxRetries: this.maxRetries,
       timeout: this.timeout,
+      idleTimeout: this.idleTimeout,
       logger: this.logger,
       logLevel: this.logLevel,
       fetch: this.fetch,
@@ -954,6 +973,7 @@ export class BaseAnthropic {
   static APIConnectionError = Errors.APIConnectionError;
   static APIConnectionTimeoutError = Errors.APIConnectionTimeoutError;
   static APIUserAbortError = Errors.APIUserAbortError;
+  static StreamIdleTimeoutError = Errors.StreamIdleTimeoutError;
   static NotFoundError = Errors.NotFoundError;
   static ConflictError = Errors.ConflictError;
   static RateLimitError = Errors.RateLimitError;

--- a/src/core/error.ts
+++ b/src/core/error.ts
@@ -116,6 +116,39 @@ export class APIConnectionTimeoutError extends APIConnectionError {
   }
 }
 
+/**
+ * Error thrown when a streaming response stalls - no SSE events received
+ * within the configured idle timeout period.
+ */
+export class StreamIdleTimeoutError extends APIConnectionError {
+  /** The configured idle timeout in milliseconds */
+  readonly idleTimeoutMs: number;
+  /** When the last SSE event was received */
+  readonly lastEventTime: Date;
+  /** Number of events received before the timeout */
+  readonly eventCount: number;
+
+  constructor({
+    idleTimeoutMs,
+    lastEventTime,
+    eventCount,
+    message,
+  }: {
+    idleTimeoutMs: number;
+    lastEventTime: Date;
+    eventCount: number;
+    message?: string;
+  }) {
+    super({
+      message:
+        message ?? `Stream stalled: no SSE event received for ${idleTimeoutMs}ms after ${eventCount} events`,
+    });
+    this.idleTimeoutMs = idleTimeoutMs;
+    this.lastEventTime = lastEventTime;
+    this.eventCount = eventCount;
+  }
+}
+
 export class BadRequestError extends APIError<400, Headers> {}
 
 export class AuthenticationError extends APIError<401, Headers> {}

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,6 +12,7 @@ export {
   APIConnectionError,
   APIConnectionTimeoutError,
   APIUserAbortError,
+  StreamIdleTimeoutError,
   NotFoundError,
   ConflictError,
   RateLimitError,

--- a/src/internal/parse.ts
+++ b/src/internal/parse.ts
@@ -27,11 +27,21 @@ export async function defaultParseResponse<T>(
       // Note: there is an invariant here that isn't represented in the type system
       // that if you set `stream: true` the response type must also be `Stream<T>`
 
+      // Pass through idle timeout from request options or client defaults
+      const streamOptions = {
+        idleTimeout: props.options.idleTimeout ?? client.idleTimeout,
+      };
+
       if (props.options.__streamClass) {
-        return props.options.__streamClass.fromSSEResponse(response, props.controller) as any;
+        return props.options.__streamClass.fromSSEResponse(
+          response,
+          props.controller,
+          client,
+          streamOptions,
+        ) as any;
       }
 
-      return Stream.fromSSEResponse(response, props.controller) as any;
+      return Stream.fromSSEResponse(response, props.controller, client, streamOptions) as any;
     }
 
     // fetch refuses to read the body when the status code is 204.

--- a/src/internal/request-options.ts
+++ b/src/internal/request-options.ts
@@ -56,6 +56,19 @@ export type RequestOptions = {
   timeout?: number;
 
   /**
+   * The maximum amount of time (in milliseconds) to wait between SSE events during streaming.
+   * If no event is received within this period, the stream will be aborted with a
+   * `StreamIdleTimeoutError`.
+   *
+   * This is distinct from `timeout` which applies to the overall request. `idleTimeout`
+   * specifically detects stalled streams where the connection is alive but no data is flowing.
+   *
+   * @unit milliseconds
+   * @default undefined (no idle timeout)
+   */
+  idleTimeout?: number;
+
+  /**
    * Additional `RequestInit` options to be passed to the underlying `fetch` call.
    * These options will be merged with the client's default fetch options.
    */

--- a/tests/api-resources/MessageStream.test.ts
+++ b/tests/api-resources/MessageStream.test.ts
@@ -1,4 +1,4 @@
-import Anthropic, { APIConnectionError, APIUserAbortError } from '@anthropic-ai/sdk';
+import Anthropic, { APIConnectionError, APIUserAbortError, StreamIdleTimeoutError } from '@anthropic-ai/sdk';
 import { Message, MessageStreamEvent } from '@anthropic-ai/sdk/resources/messages';
 import { mockFetch } from '../lib/mock-fetch';
 import { loadFixture, parseSSEFixture } from '../lib/sse-helpers';
@@ -250,5 +250,147 @@ describe('MessageStream class', () => {
       throw new Error('mock request error');
     });
     await expect(stream).rejects.toThrow(APIConnectionError);
+  });
+
+  describe('idle timeout integration', () => {
+    it('throws StreamIdleTimeoutError when stream stalls via request options', async () => {
+      const { fetch, handleRequest } = mockFetch();
+      const anthropic = new Anthropic({ apiKey: 'test-key', fetch });
+
+      // Create a stream that sends one event then stalls
+      handleRequest(async () => {
+        const { PassThrough } = await import('stream');
+        const stream = new PassThrough();
+
+        // Send one event then stall
+        stream.write('event: message_start\n');
+        stream.write(
+          'data: {"type":"message_start","message":{"id":"msg_1","type":"message","role":"assistant","content":[],"model":"claude","stop_reason":null,"stop_sequence":null,"usage":{"input_tokens":0,"output_tokens":0}}}\n\n',
+        );
+        // Don't end the stream - it will stall
+
+        return new Response(stream, {
+          headers: { 'Content-Type': 'text/event-stream' },
+        });
+      });
+
+      const stream = anthropic.messages.stream(
+        {
+          max_tokens: 1024,
+          model: 'claude-opus-4-20250514',
+          messages: [{ role: 'user', content: 'Hello' }],
+        },
+        { idleTimeout: 50 }, // 50ms timeout
+      );
+
+      await expect(stream.finalMessage()).rejects.toThrow(StreamIdleTimeoutError);
+    });
+
+    it('throws StreamIdleTimeoutError when stream stalls via client default', async () => {
+      const { fetch, handleRequest } = mockFetch();
+      const anthropic = new Anthropic({
+        apiKey: 'test-key',
+        fetch,
+        idleTimeout: 50, // Default idle timeout for all requests
+      });
+
+      // Create a stream that sends one event then stalls
+      handleRequest(async () => {
+        const { PassThrough } = await import('stream');
+        const stream = new PassThrough();
+
+        stream.write('event: message_start\n');
+        stream.write(
+          'data: {"type":"message_start","message":{"id":"msg_1","type":"message","role":"assistant","content":[],"model":"claude","stop_reason":null,"stop_sequence":null,"usage":{"input_tokens":0,"output_tokens":0}}}\n\n',
+        );
+        // Stall
+
+        return new Response(stream, {
+          headers: { 'Content-Type': 'text/event-stream' },
+        });
+      });
+
+      const stream = anthropic.messages.stream({
+        max_tokens: 1024,
+        model: 'claude-opus-4-20250514',
+        messages: [{ role: 'user', content: 'Hello' }],
+      });
+
+      await expect(stream.finalMessage()).rejects.toThrow(StreamIdleTimeoutError);
+    });
+
+    it('request idleTimeout overrides client default', async () => {
+      const { fetch, handleRequest } = mockFetch();
+      const anthropic = new Anthropic({
+        apiKey: 'test-key',
+        fetch,
+        idleTimeout: 10, // Very short default that would timeout
+      });
+
+      // Create a slow but completing stream
+      handleRequest(async () => {
+        const { PassThrough } = await import('stream');
+        const stream = new PassThrough();
+
+        (async () => {
+          stream.write('event: message_start\n');
+          stream.write(
+            'data: {"type":"message_start","message":{"id":"msg_1","type":"message","role":"assistant","content":[],"model":"claude","stop_reason":null,"stop_sequence":null,"usage":{"input_tokens":0,"output_tokens":0}}}\n\n',
+          );
+          await new Promise((r) => setTimeout(r, 30)); // 30ms delay
+          stream.write('event: message_stop\n');
+          stream.write('data: {"type":"message_stop"}\n\n');
+          stream.end();
+        })();
+
+        return new Response(stream, {
+          headers: { 'Content-Type': 'text/event-stream' },
+        });
+      });
+
+      // Override with longer timeout
+      const stream = anthropic.messages.stream(
+        {
+          max_tokens: 1024,
+          model: 'claude-opus-4-20250514',
+          messages: [{ role: 'user', content: 'Hello' }],
+        },
+        { idleTimeout: 100 }, // Override with longer timeout
+      );
+
+      // Should complete successfully despite client's short default
+      const events: MessageStreamEvent[] = [];
+      for await (const event of stream) {
+        events.push(event);
+      }
+      expect(events.length).toBe(2);
+    });
+
+    it('stream completes normally when data arrives before timeout', async () => {
+      const { fetch, handleStreamEvents } = mockFetch();
+      const anthropic = new Anthropic({
+        apiKey: 'test-key',
+        fetch,
+        idleTimeout: 1000, // Long timeout
+      });
+
+      const fixtureContent = loadFixture('basic_response.txt');
+      const streamEvents = await parseSSEFixture(fixtureContent);
+      handleStreamEvents(streamEvents);
+
+      const stream = anthropic.messages.stream({
+        max_tokens: 1024,
+        model: 'claude-opus-4-20250514',
+        messages: [{ role: 'user', content: 'Say hello there!' }],
+      });
+
+      const events: MessageStreamEvent[] = [];
+      for await (const event of stream) {
+        events.push(event);
+      }
+
+      const message = await stream.finalMessage();
+      assertBasicResponse(events, message);
+    });
   });
 });

--- a/tests/streaming.test.ts
+++ b/tests/streaming.test.ts
@@ -396,4 +396,233 @@ describe('idle timeout', () => {
     // Second call should timeout
     await expect(iterator.next()).rejects.toThrow(StreamIdleTimeoutError);
   });
+
+  test('cleans up timer on normal stream completion', async () => {
+    const clearTimeoutSpy = jest.spyOn(global, 'clearTimeout');
+
+    async function* body(): AsyncGenerator<Buffer> {
+      yield Buffer.from('event: message_start\n');
+      yield Buffer.from('data: {"type":"message_start"}\n');
+      yield Buffer.from('\n');
+      yield Buffer.from('event: message_stop\n');
+      yield Buffer.from('data: {"type":"message_stop"}\n');
+      yield Buffer.from('\n');
+    }
+
+    const controller = new AbortController();
+    const stream = _iterSSEMessages(new Response(ReadableStreamFrom(body())), controller, {
+      idleTimeout: 1000,
+    });
+
+    const events = [];
+    for await (const event of stream) {
+      events.push(event);
+    }
+
+    expect(events.length).toBe(2);
+    // Timer should have been cleared (once per chunk + final)
+    expect(clearTimeoutSpy).toHaveBeenCalled();
+    clearTimeoutSpy.mockRestore();
+  });
+
+  test('cleans up timer when user breaks out of loop', async () => {
+    const clearTimeoutSpy = jest.spyOn(global, 'clearTimeout');
+
+    async function* body(): AsyncGenerator<Buffer> {
+      yield Buffer.from('event: event1\n\n');
+      yield Buffer.from('event: event2\n\n');
+      yield Buffer.from('event: event3\n\n');
+      // More events that won't be consumed
+      yield Buffer.from('event: event4\n\n');
+    }
+
+    const controller = new AbortController();
+    const stream = _iterSSEMessages(new Response(ReadableStreamFrom(body())), controller, {
+      idleTimeout: 1000,
+    });
+
+    let count = 0;
+    for await (const _event of stream) {
+      count++;
+      if (count >= 2) break; // Break early
+    }
+
+    expect(count).toBe(2);
+    // Allow microtask queue to flush
+    await new Promise((resolve) => setTimeout(resolve, 10));
+    expect(clearTimeoutSpy).toHaveBeenCalled();
+    clearTimeoutSpy.mockRestore();
+  });
+
+  test('cleans up timer on manual abort', async () => {
+    const clearTimeoutSpy = jest.spyOn(global, 'clearTimeout');
+
+    async function* body(): AsyncGenerator<Buffer> {
+      yield Buffer.from('event: message_start\n\n');
+      await new Promise((resolve) => setTimeout(resolve, 100));
+      yield Buffer.from('event: message_stop\n\n');
+    }
+
+    const controller = new AbortController();
+    const stream = _iterSSEMessages(new Response(ReadableStreamFrom(body())), controller, {
+      idleTimeout: 1000,
+    });
+
+    const iterator = stream[Symbol.asyncIterator]();
+
+    // Get first event
+    await iterator.next();
+
+    // Abort while waiting for second
+    setTimeout(() => controller.abort(), 20);
+
+    // The next call should handle the abort
+    try {
+      await iterator.next();
+    } catch (e) {
+      // Abort error is expected
+    }
+
+    expect(clearTimeoutSpy).toHaveBeenCalled();
+    clearTimeoutSpy.mockRestore();
+  });
+
+  test('handles very short idleTimeout', async () => {
+    // Test that a very short timeout (1ms) still works correctly
+    // Note: setTimeout(fn, 0) behavior allows synchronously-available data through,
+    // so we use 1ms and add a small delay to ensure timeout fires
+    async function* body(): AsyncGenerator<Buffer> {
+      yield Buffer.from('event: message_start\n\n');
+      await new Promise((resolve) => setTimeout(resolve, 20)); // Delay longer than timeout
+      yield Buffer.from('event: message_stop\n\n');
+    }
+
+    const controller = new AbortController();
+    const stream = _iterSSEMessages(new Response(ReadableStreamFrom(body())), controller, {
+      idleTimeout: 1, // Very short timeout
+    });
+
+    const events = [];
+    try {
+      for await (const event of stream) {
+        events.push(event);
+      }
+      fail('Should have thrown');
+    } catch (err) {
+      expect(err).toBeInstanceOf(StreamIdleTimeoutError);
+    }
+
+    // First event should have come through before timeout
+    expect(events.length).toBe(1);
+  });
+
+  test('works correctly with multiple sequential streams', async () => {
+    // Ensure no cross-contamination between streams
+    async function* fastBody(): AsyncGenerator<Buffer> {
+      yield Buffer.from('event: fast\n\n');
+    }
+
+    async function* slowBody(): AsyncGenerator<Buffer> {
+      yield Buffer.from('event: slow\n\n');
+      await new Promise((resolve) => setTimeout(resolve, 30));
+      yield Buffer.from('event: slow2\n\n');
+    }
+
+    // First stream with short timeout
+    const stream1 = _iterSSEMessages(new Response(ReadableStreamFrom(fastBody())), new AbortController(), {
+      idleTimeout: 100,
+    });
+
+    const events1 = [];
+    for await (const event of stream1) {
+      events1.push(event);
+    }
+    expect(events1.length).toBe(1);
+
+    // Second stream with different timeout - should not be affected by first
+    const stream2 = _iterSSEMessages(new Response(ReadableStreamFrom(slowBody())), new AbortController(), {
+      idleTimeout: 100,
+    });
+
+    const events2 = [];
+    for await (const event of stream2) {
+      events2.push(event);
+    }
+    expect(events2.length).toBe(2);
+  });
+
+  test('timeout error includes accurate event count across multiple chunks', async () => {
+    async function* body(): AsyncGenerator<Buffer> {
+      // Send 5 chunks before stalling
+      for (let i = 0; i < 5; i++) {
+        yield Buffer.from(`event: event${i}\n\n`);
+      }
+      await new Promise(() => {}); // Stall
+    }
+
+    const controller = new AbortController();
+    const stream = _iterSSEMessages(new Response(ReadableStreamFrom(body())), controller, {
+      idleTimeout: 50,
+    });
+
+    const events = [];
+    try {
+      for await (const event of stream) {
+        events.push(event);
+      }
+      fail('Should have thrown');
+    } catch (err) {
+      expect(err).toBeInstanceOf(StreamIdleTimeoutError);
+      const timeoutErr = err as StreamIdleTimeoutError;
+      // We received 5 chunks before timeout
+      expect(timeoutErr.eventCount).toBe(5);
+    }
+
+    expect(events.length).toBe(5);
+  });
+
+  test('does not leak timers when error occurs during chunk processing', async () => {
+    const setTimeoutSpy = jest.spyOn(global, 'setTimeout');
+    const clearTimeoutSpy = jest.spyOn(global, 'clearTimeout');
+
+    async function* body(): AsyncGenerator<Buffer> {
+      yield Buffer.from('event: good\n\n');
+      yield Buffer.from('event: bad\n\n');
+    }
+
+    const controller = new AbortController();
+    const stream = _iterSSEMessages(new Response(ReadableStreamFrom(body())), controller, {
+      idleTimeout: 1000,
+    });
+
+    let errorThrown = false;
+    try {
+      let count = 0;
+      for await (const _event of stream) {
+        count++;
+        if (count === 2) {
+          throw new Error('Processing error');
+        }
+      }
+    } catch (e) {
+      if ((e as Error).message === 'Processing error') {
+        errorThrown = true;
+      } else {
+        throw e;
+      }
+    }
+
+    expect(errorThrown).toBe(true);
+
+    // Get counts before restore
+    const setCount = setTimeoutSpy.mock.calls.length;
+    const clearCount = clearTimeoutSpy.mock.calls.length;
+
+    setTimeoutSpy.mockRestore();
+    clearTimeoutSpy.mockRestore();
+
+    // Each setTimeout should have a corresponding clearTimeout
+    // (may have more clears than sets due to the error path)
+    expect(clearCount).toBeGreaterThanOrEqual(setCount - 1);
+  });
 });


### PR DESCRIPTION
# This is an example PR for what's brought up in #867 

I tried to ensure good test coverage.

## Summary

This PR adds an `idleTimeout` option to detect and abort streams that stop sending SSE events without closing the connection. This addresses a critical failure mode where streaming responses hang indefinitely when:

- Network connectivity becomes unstable mid-stream
- The API server experiences transient issues
- Load balancers or proxies close connections without proper cleanup

### The Problem

Currently, the SDK provides:
- `timeout`: Overall request timeout (covers connection + response time)
- `AbortController`: Manual cancellation via signals

Neither detects **stalled streams** where the connection is alive but no data is flowing. When this happens, `for await (const event of stream)` blocks forever with no error and no indication anything is wrong.

### Real-World Evidence

From production Claude Code CLI sessions, we observed:
- Sessions hanging for 15+ minutes with 0% CPU (waiting for data)
- `"stop_reason": null` in logs - response never completed
- Only solution was to kill the process, losing all work in progress

### The Solution

New `idleTimeout` option that:
1. Tracks time since the last SSE event was received
2. Uses `Promise.race` to race each chunk read against a timeout
3. Throws `StreamIdleTimeoutError` with diagnostic information if the stream stalls

## Changes

| File | Change |
|------|--------|
| `src/client.ts` | Add `idleTimeout` to `ClientOptions` |
| `src/internal/request-options.ts` | Add `idleTimeout` to `RequestOptions` |
| `src/core/error.ts` | Add `StreamIdleTimeoutError` class |
| `src/core/streaming.ts` | Implement timeout in `_iterSSEMessages` |
| `src/internal/parse.ts` | Pass options through to `Stream.fromSSEResponse` |
| `src/index.ts` | Export `StreamIdleTimeoutError` |
| `tests/streaming.test.ts` | Add 13 idle timeout unit tests |
| `tests/api-resources/MessageStream.test.ts` | Add 4 client-level integration tests |

## API

```typescript
// Set default idle timeout for all streams (90 seconds)
const client = new Anthropic({
  idleTimeout: 90_000,
});

// Override per-request
const stream = await client.messages.stream(params, {
  idleTimeout: 120_000, // 2 minutes for this specific request
});

// Catch the specific error type
try {
  for await (const event of stream) {
    // process events
  }
} catch (err) {
  if (err instanceof Anthropic.StreamIdleTimeoutError) {
    console.log(`Stream stalled after ${err.eventCount} events`);
    console.log(`Last event at: ${err.lastEventTime}`);
    console.log(`Configured timeout: ${err.idleTimeoutMs}ms`);
    // Retry or fail gracefully
  }
}
```

## Type Safety

- All new properties are optional (backward compatible)
- No `any` types used
- `StreamIdleTimeoutError` extends `APIConnectionError` (existing error hierarchy)
- `idleTimeout?: number | undefined` to satisfy `exactOptionalPropertyTypes`

## Test Plan

- [x] `npm run lint` passes
- [x] `npm test` passes (427 tests total, including 17 new idle timeout tests)
- [x] Types compile correctly

### Test Coverage

#### Low-Level Unit Tests (`streaming.test.ts`) - 13 tests

| Test | Purpose |
|------|---------|
| Basic timeout fires | Core functionality works |
| Timeout resets on data | Slow but consistent streams complete |
| Error has diagnostic info | `idleTimeoutMs`, `eventCount`, `lastEventTime` |
| No timeout without option | Backward compatibility |
| Options pass through Stream | Factory pattern works |
| Cleanup on normal completion | No timer memory leaks |
| Cleanup on user break | No leaks when breaking from loop |
| Cleanup on manual abort | No leaks on `controller.abort()` |
| Very short timeout (1ms) | Edge case behavior |
| Multiple sequential streams | No cross-contamination |
| Accurate event count | Diagnostic accuracy |
| No timer leak on processing error | Exception safety |

#### Client Integration Tests (`MessageStream.test.ts`) - 4 tests

| Test | Purpose |
|------|---------|
| Timeout via request options | `client.messages.stream(params, { idleTimeout })` |
| Timeout via client default | `new Anthropic({ idleTimeout })` |
| Request overrides client | Option precedence works |
| Normal completion with timeout | No false positives |

## Questions for Maintainers

1. **Default value**: Should `idleTimeout` have a default (e.g., 2 minutes) or remain opt-in?
2. **Ping events**: Should `ping` SSE events reset the idle timer, or only "meaningful" events?
3. **Retry integration**: Should idle timeout trigger retry logic if `maxRetries > 0`?