### PR TITLE
docs: correct broken compare links in CHANGELOG.md files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -491,7 +491,7 @@ Full Changelog: [sdk-v0.50.0...sdk-v0.50.1](https://github.com/anthropics/anthro
 
 ## 0.50.0 (2025-05-09)
 
-Full Changelog: [sdk-v0.41.0...sdk-v0.50.0](https://github.com/anthropics/anthropic-sdk-typescript/compare/sdk-v0.41.0...sdk-v0.42.0)
+Full Changelog: [sdk-v0.41.0...sdk-v0.50.0](https://github.com/anthropics/anthropic-sdk-typescript/compare/sdk-v0.41.0...sdk-v0.50.0)
 
 ### Features
 
@@ -1601,7 +1601,7 @@ Full Changelog: [sdk-v0.12.4...sdk-v0.12.5](https://github.com/anthropics/anthro
 
 ## 0.12.4 (2024-01-23)
 
-Full Changelog: [sdk-v0.12.3...sdk-v0.12.4](https://github.com/anthropics/anthropic-sdk-typescript/compare/sdk-v0.12.3...sdk-v0.12.4)
+Full Changelog: [v0.12.3...sdk-v0.12.4](https://github.com/anthropics/anthropic-sdk-typescript/compare/v0.12.3...sdk-v0.12.4)
 
 ### Chores
 

--- a/packages/bedrock-sdk/CHANGELOG.md
+++ b/packages/bedrock-sdk/CHANGELOG.md
@@ -109,7 +109,7 @@ Full Changelog: [bedrock-sdk-v0.21.0...bedrock-sdk-v0.21.1](https://github.com/a
 
 ## 0.21.0 (2025-05-09)
 
-Full Changelog: [bedrock-sdk-v0.20.0...bedrock-sdk-v0.21.0](https://github.com/anthropics/anthropic-sdk-typescript/compare/bedrock-sdk-v0.20.0...bedrock-sdk-v0.21.0)
+Full Changelog: [bedrock-sdk-v0.12.7...bedrock-sdk-v0.21.0](https://github.com/anthropics/anthropic-sdk-typescript/compare/bedrock-sdk-v0.12.7...bedrock-sdk-v0.21.0)
 
 ### Features
 
@@ -145,7 +145,7 @@ Full Changelog: [bedrock-sdk-v0.20.0...bedrock-sdk-v0.21.0](https://github.com/a
 
 ## 0.20.0 (2025-05-09)
 
-Full Changelog: [bedrock-sdk-v0.12.6...bedrock-sdk-v0.12.7](https://github.com/anthropics/anthropic-sdk-typescript/compare/bedrock-sdk-v0.12.6...bedrock-sdk-v0.12.7)
+~~Full Changelog: bedrock-sdk-v0.12.6...bedrock-sdk-v0.12.7~~ *
 
 ### Bug Fixes
 
@@ -374,7 +374,7 @@ Full Changelog: [bedrock-sdk-v0.7.1...bedrock-sdk-v0.8.0](https://github.com/ant
 
 ## 0.7.1 (2024-01-31)
 
-Full Changelog: [bedrock-sdk-v0.7.0...bedrock-sdk-v0.7.1](https://github.com/anthropics/anthropic-sdk-typescript/compare/bedrock-sdk-v0.7.0...bedrock-sdk-v0.7.1)
+~~Full Changelog: bedrock-sdk-v0.7.0...bedrock-sdk-v0.7.1~~ *
 
 ### Chores
 
@@ -606,3 +606,7 @@ Full Changelog: [v0.0.1...v0.1.0](https://github.com/anthropics/anthropic-bedroc
 ### Features
 
 * **init:** initial commit ([#1](https://github.com/anthropics/anthropic-bedrock-typescript/issues/1)) ([17f9073](https://github.com/anthropics/anthropic-bedrock-typescript/commit/17f9073f1545f9f578e67c56f827322a7691ca21))
+
+---
+
+\* _Invalid compare link: referenced git tag does not exist. See PR for details._

--- a/packages/foundry-sdk/CHANGELOG.md
+++ b/packages/foundry-sdk/CHANGELOG.md
@@ -6,7 +6,7 @@ Full Changelog: [foundry-sdk-v0.2.0...foundry-sdk-v0.2.1](https://github.com/ant
 
 ## 0.2.0 (2025-11-18)
 
-Full Changelog: [foundry-sdk-v0.1.0...foundry-sdk-v0.2.0](https://github.com/anthropics/anthropic-sdk-typescript/compare/foundry-sdk-v0.1.0...foundry-sdk-v0.2.0)
+~~Full Changelog: foundry-sdk-v0.1.0...foundry-sdk-v0.2.0~~ *
 
 ### Features
 
@@ -17,5 +17,9 @@ Full Changelog: [foundry-sdk-v0.1.0...foundry-sdk-v0.2.0](https://github.com/ant
 
 * **internal:** version bump ([eb97e85](https://github.com/anthropics/anthropic-sdk-typescript/commit/eb97e8577279fb150582297d2a0924a297185c3c))
 * **internal:** version bump ([8ebaf61](https://github.com/anthropics/anthropic-sdk-typescript/commit/8ebaf616d2e5c6aebc153f19a403dde41ab5a9f1))
+
+---
+
+\* _Invalid compare link: referenced git tag does not exist. See PR for details._
 
 ## Changelog

--- a/packages/vertex-sdk/CHANGELOG.md
+++ b/packages/vertex-sdk/CHANGELOG.md
@@ -92,7 +92,7 @@ Full Changelog: [vertex-sdk-v0.11.0...vertex-sdk-v0.11.1](https://github.com/ant
 
 ## 0.11.0 (2025-05-09)
 
-Full Changelog: [vertex-sdk-v0.10.0...vertex-sdk-v0.11.0](https://github.com/anthropics/anthropic-sdk-typescript/compare/vertex-sdk-v0.10.0...vertex-sdk-v0.11.0)
+Full Changelog: [vertex-sdk-v0.7.1...vertex-sdk-v0.11.0](https://github.com/anthropics/anthropic-sdk-typescript/compare/vertex-sdk-v0.7.1...vertex-sdk-v0.11.0)
 
 ### Features
 
@@ -125,7 +125,7 @@ Full Changelog: [vertex-sdk-v0.10.0...vertex-sdk-v0.11.0](https://github.com/ant
 
 ## 0.10.0 (2025-05-09)
 
-Full Changelog: [vertex-sdk-v0.7.0...vertex-sdk-v0.7.1](https://github.com/anthropics/anthropic-sdk-typescript/compare/vertex-sdk-v0.7.0...vertex-sdk-v0.7.1)
+~~Full Changelog: vertex-sdk-v0.7.0...vertex-sdk-v0.7.1~~ *
 
 ### Bug Fixes
 
@@ -364,8 +364,12 @@ Full Changelog: [vertex-sdk-v0.1.0...vertex-sdk-v0.1.1](https://github.com/anthr
 
 ## 0.1.0 (2024-01-23)
 
-Full Changelog: [vertex-sdk-v0.0.1...vertex-sdk-v0.1.0](https://github.com/anthropics/anthropic-sdk-typescript/compare/vertex-sdk-v0.0.1...vertex-sdk-v0.1.0)
+~~Full Changelog: vertex-sdk-v0.0.1...vertex-sdk-v0.1.0~~ *
 
 ### Features
 
 * **vertex:** add support for google vertex ([#265](https://github.com/anthropics/anthropic-sdk-typescript/issues/265)) ([9a0410d](https://github.com/anthropics/anthropic-sdk-typescript/commit/9a0410d4e870d796b7def0a6a241e9d409e97886))
+
+---
+
+\* _Invalid compare link: referenced git tag does not exist. See PR for details._


### PR DESCRIPTION
Resolves #875

## Summary
Several compare links in CHANGELOG.md files referenced git tags that don't exist, causing 404 errors when clicked. This was due to:
1. A URL typo in root CHANGELOG
2. Tag naming convention changes (v0.x.x → sdk-v0.x.x)
3. Version jumps where tags were never created
4. Phantom CHANGELOG entries for versions that were never published

## Changes Made

### Root CHANGELOG.md
- Fixed typo: `sdk-v0.42.0` → `sdk-v0.50.0` in URL (line 494)
- Fixed tag format: `sdk-v0.12.3` → `v0.12.3` (line 1604)

### packages/bedrock-sdk/CHANGELOG.md
- Fixed link: `bedrock-sdk-v0.20.0` → `bedrock-sdk-v0.12.7` (actual previous tag)
- Struck through invalid link for v0.20.0 (phantom entry with wrong link)
- Struck through invalid link for v0.7.1 (missing v0.7.0 tag)
- Added footer note explaining strikethrough entries

### packages/vertex-sdk/CHANGELOG.md
- Fixed link: `vertex-sdk-v0.10.0` → `vertex-sdk-v0.7.1` (actual previous tag)
- Struck through invalid link for v0.10.0 (phantom entry with wrong link)
- Struck through invalid link for v0.1.0 (missing v0.0.1 tag)
- Added footer note explaining strikethrough entries

### packages/foundry-sdk/CHANGELOG.md
- Struck through invalid link for v0.2.0 (missing v0.1.0 tag)
- Added footer note explaining strikethrough entries

## Investigation Notes
- The old `anthropic-bedrock-typescript` repo still exists and those links remain valid
- Some CHANGELOG entries exist for versions never published to npm (phantom versions)
- Invalid links are preserved with strikethrough to maintain historical record

🤖 Generated with [Claude Code](https://claude.com/claude-code)