### PR TITLE
fix(BetaToolRunner): Fix infinite loop logic and message loss when compaction occurs

### DIFF
--- a/src/lib/tools/BetaToolRunner.ts
+++ b/src/lib/tools/BetaToolRunner.ts
@@ -204,13 +204,13 @@ export class BetaToolRunner<Stream extends boolean> {
               const { role, content } = await this.#message;
               this.#state.params.messages.push({ role, content });
             }
+          }
 
-            const toolMessage = await this.#generateToolResponse(this.#state.params.messages.at(-1)!);
-            if (toolMessage) {
-              this.#state.params.messages.push(toolMessage);
-            } else if (!this.#mutated) {
-              break;
-            }
+          const toolMessage = await this.#generateToolResponse(this.#state.params.messages.at(-1)!);
+          if (toolMessage) {
+            this.#state.params.messages.push(toolMessage);
+          } else if (!this.#mutated) {
+            break;
           }
         } finally {
           if (stream) {

--- a/src/lib/tools/BetaToolRunner.ts
+++ b/src/lib/tools/BetaToolRunner.ts
@@ -198,12 +198,11 @@ export class BetaToolRunner<Stream extends boolean> {
             yield this.#message as any;
           }
 
-          const isCompacted = await this.#checkAndCompact();
-          if (!isCompacted) {
-            if (!this.#mutated) {
-              const { role, content } = await this.#message;
-              this.#state.params.messages.push({ role, content });
-            }
+          await this.#checkAndCompact();
+
+          if (!this.#mutated) {
+            const { role, content } = await this.#message;
+            this.#state.params.messages.push({ role, content });
           }
 
           const toolMessage = await this.#generateToolResponse(this.#state.params.messages.at(-1)!);


### PR DESCRIPTION
## Problem
Currently, the `BetaToolRunner` logic inside the `while` loop places the message pushing and tool execution logic inside an `if (!isCompacted)` block.
This causes two critical issues when compaction occurs:
1. **Infinite Loop**: The loop termination condition (`break`) is skipped, causing an infinite loop.
2. **Message Loss**: The current assistant message (containing `tool_use`) is not added to the history because the push operation is skipped. Since `checkAndCompact` only summarizes existing history and does not include the current message, the current message is effectively lost. This breaks the conversation flow and prevents tool execution.

## Solution
I removed the `if (!isCompacted)` condition wrapping the message handling logic.
Now, the runner performs steps sequentially:
1. Checks and compacts history if needed.
2. **Always** pushes the current assistant message to history (ensuring the context is preserved even after compaction).
3. Checks for tool execution and handles results or breaks the loop.