### PR TITLE
fix(bedrock): eliminate race condition in AWS credential resolution

### DIFF
--- a/packages/bedrock-sdk/src/core/auth.ts
+++ b/packages/bedrock-sdk/src/core/auth.ts
@@ -43,31 +43,19 @@ const DEFAULT_PROVIDER_CHAIN_RESOLVER: () => Promise<AwsCredentialIdentityProvid
 export const getAuthHeaders = async (req: RequestInit, props: AuthProps): Promise<Record<string, string>> => {
   assert(req.method, 'Expected request method property to be set');
 
-  const providerChain = await (props.providerChainResolver ?
-    props.providerChainResolver()
-  : DEFAULT_PROVIDER_CHAIN_RESOLVER());
-
-  const credentials = await withTempEnv(
-    () => {
-      // Temporarily set the appropriate environment variables if we've been
-      // explicitly given credentials so that the credentials provider can
-      // resolve them.
-      //
-      // Note: the environment provider is only not run first if the `AWS_PROFILE`
-      // environment variable is set.
-      // https://github.com/aws/aws-sdk-js-v3/blob/44a18a34b2c93feccdfcd162928d13e6dbdcaf30/packages/credential-provider-node/src/defaultProvider.ts#L49
-      if (props.awsAccessKey) {
-        process.env['AWS_ACCESS_KEY_ID'] = props.awsAccessKey;
-      }
-      if (props.awsSecretKey) {
-        process.env['AWS_SECRET_ACCESS_KEY'] = props.awsSecretKey;
-      }
-      if (props.awsSessionToken) {
-        process.env['AWS_SESSION_TOKEN'] = props.awsSessionToken;
-      }
-    },
-    () => providerChain(),
-  );
+  let credentials;
+  if (props.awsAccessKey && props.awsSecretKey) {
+    credentials = {
+      accessKeyId: props.awsAccessKey,
+      secretAccessKey: props.awsSecretKey,
+      ...(props.awsSessionToken != null && { sessionToken: props.awsSessionToken }),
+    };
+  } else {
+    const provider = await (props.providerChainResolver ?
+      props.providerChainResolver()
+    : DEFAULT_PROVIDER_CHAIN_RESOLVER());
+    credentials = await provider();
+  }
 
   const signer = new SignatureV4({
     service: 'bedrock',
@@ -100,15 +88,4 @@ export const getAuthHeaders = async (req: RequestInit, props: AuthProps): Promis
 
   const signed = await signer.sign(request);
   return signed.headers;
-};
-
-const withTempEnv = async <R>(updateEnv: () => void, fn: () => Promise<R>): Promise<R> => {
-  const previousEnv = { ...process.env };
-
-  try {
-    updateEnv();
-    return await fn();
-  } finally {
-    process.env = previousEnv;
-  }
 };

--- a/packages/bedrock-sdk/tests/client.test.ts
+++ b/packages/bedrock-sdk/tests/client.test.ts
@@ -1,3 +1,5 @@
+import AnthropicBedrock from '../src';
+
 // Mock the client to allow for a more integration-style test
 // We're mocking specific parts of the AnthropicBedrock client to avoid
 // dependencies while still testing the integration behavior
@@ -109,5 +111,47 @@ describe('Bedrock model ARN URL encoding integration test', () => {
 
     // Verify the exact URL matches what we expect
     expect(fetchUrl).toBe(expectedUrl);
+  });
+});
+
+describe('AnthropicBedrock constructor deprecation warnings', () => {
+  let consoleWarnSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    consoleWarnSpy = jest.spyOn(console, 'warn').mockImplementation();
+    jest.resetModules();
+  });
+
+  afterEach(() => {
+    consoleWarnSpy.mockRestore();
+  });
+
+  test('does not warn when both credentials are provided', () => {
+    new AnthropicBedrock({
+      awsAccessKey: 'access-key',
+      awsSecretKey: 'secret-key',
+      awsRegion: 'us-east-1',
+    });
+
+    expect(consoleWarnSpy).not.toHaveBeenCalled();
+  });
+
+  test('does not warn when neither credential is provided', () => {
+    new AnthropicBedrock({
+      awsRegion: 'us-east-1',
+    });
+
+    expect(consoleWarnSpy).not.toHaveBeenCalled();
+  });
+
+  test('warns when only one credential is provided', () => {
+    new AnthropicBedrock({
+      awsAccessKey: 'access-key',
+      awsRegion: 'us-east-1',
+    });
+
+    expect(consoleWarnSpy).toHaveBeenCalledWith(
+      expect.stringContaining('Passing only one of `awsAccessKey` or `awsSecretKey` is deprecated'),
+    );
   });
 });


### PR DESCRIPTION
# Fix AWS Credentials Race Condition

## Problem

The previous implementation used `withTempEnv()` to temporarily set AWS environment variables (`AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, `AWS_SESSION_TOKEN`) globally in `process.env` during credential resolution. Since `process.env` is global state, concurrent requests could interfere with each other, causing race conditions where one request might use credentials intended for another.

## Solution

This PR eliminates the race condition by using static credentials directly when both `awsAccessKey` and `awsSecretKey` are provided, bypassing the need for environment variable manipulation. The AWS provider chain is only invoked when static credentials are not fully provided.

## Migration Path

Users passing only one credential will see a deprecation warning but the code will continue to work (falling back to the provider chain). To remove the warning, users should:
- Provide both `awsAccessKey` and `awsSecretKey`, OR
- Provide neither and rely on the AWS credential provider chain

```typescript
// bad - deprecated
new AnthropicBedrock({
  awsAccessKey: 'test',
});

// good
new AnthropicBedrock({
  awsAccessKey: 'test',
  awsSecretKey: 'test',
});
```
