### PR TITLE
fix(streaming): skip SSE events with empty data to prevent JSON parse crash

### DIFF
--- a/src/core/streaming.ts
+++ b/src/core/streaming.ts
@@ -49,6 +49,11 @@ export class Stream<Item> implements AsyncIterable<Item> {
       try {
         for await (const sse of _iterSSEMessages(response, controller)) {
           if (sse.event === 'completion') {
+            // Skip events with empty data — can occur in edge/cloud environments
+            // when network proxies split SSE chunks between event and data lines
+            if (!sse.data) {
+              continue;
+            }
             try {
               yield JSON.parse(sse.data);
             } catch (e) {
@@ -66,6 +71,11 @@ export class Stream<Item> implements AsyncIterable<Item> {
             sse.event === 'content_block_delta' ||
             sse.event === 'content_block_stop'
           ) {
+            // Skip events with empty data — can occur in edge/cloud environments
+            // when network proxies split SSE chunks between event and data lines
+            if (!sse.data) {
+              continue;
+            }
             try {
               yield JSON.parse(sse.data);
             } catch (e) {

--- a/tests/streaming.test.ts
+++ b/tests/streaming.test.ts
@@ -243,3 +243,341 @@ test('error handling', async () => {
   );
   await err.toBeInstanceOf(APIError);
 });
+
+// =====================================================================
+// Tests for empty SSE data handling (fixes #292 regression, #861)
+//
+// In edge/cloud environments (Vercel Edge, Cloudflare Workers), network
+// proxies and CDNs can split SSE chunks so that an event line arrives
+// without its corresponding data line. The SSEDecoder correctly produces
+// an event with data='', but Stream.fromSSEResponse must not crash when
+// trying to JSON.parse('').
+// =====================================================================
+
+describe('Stream.fromSSEResponse — empty data resilience', () => {
+  /**
+   * Helper: collects all items from a Stream into an array.
+   */
+  async function collect<T>(stream: Stream<T>): Promise<T[]> {
+    const items: T[] = [];
+    for await (const item of stream) {
+      items.push(item);
+    }
+    return items;
+  }
+
+  // -- Per-event-type tests: each Anthropic event type with empty data --
+
+  const messageEventTypes = [
+    'message_start',
+    'message_delta',
+    'message_stop',
+    'content_block_start',
+    'content_block_delta',
+    'content_block_stop',
+  ] as const;
+
+  test.each(messageEventTypes)(
+    'skips %s event with empty data without crashing',
+    async (eventType) => {
+      async function* body(): AsyncGenerator<Buffer> {
+        // Event with no data line — SSEDecoder will produce data=''
+        yield Buffer.from(`event: ${eventType}\n`);
+        yield Buffer.from('\n');
+      }
+
+      const stream = Stream.fromSSEResponse(
+        new Response(ReadableStreamFrom(body())),
+        new AbortController(),
+      );
+
+      const items = await collect(stream);
+      expect(items).toHaveLength(0);
+    },
+  );
+
+  test('skips completion event with empty data without crashing', async () => {
+    async function* body(): AsyncGenerator<Buffer> {
+      yield Buffer.from('event: completion\n');
+      yield Buffer.from('\n');
+    }
+
+    const stream = Stream.fromSSEResponse(
+      new Response(ReadableStreamFrom(body())),
+      new AbortController(),
+    );
+
+    const items = await collect(stream);
+    expect(items).toHaveLength(0);
+  });
+
+  // -- Stream continues after empty-data events --
+
+  test('stream continues processing valid events after empty-data event', async () => {
+    async function* body(): AsyncGenerator<Buffer> {
+      // First: empty content_block_delta (should be skipped)
+      yield Buffer.from('event: content_block_delta\n');
+      yield Buffer.from('\n');
+      // Second: valid content_block_delta (should be yielded)
+      yield Buffer.from('event: content_block_delta\n');
+      yield Buffer.from('data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"Hi"}}\n');
+      yield Buffer.from('\n');
+    }
+
+    const stream = Stream.fromSSEResponse(
+      new Response(ReadableStreamFrom(body())),
+      new AbortController(),
+    );
+
+    const items = await collect(stream);
+    expect(items).toHaveLength(1);
+    expect(items[0]).toEqual({
+      type: 'content_block_delta',
+      index: 0,
+      delta: { type: 'text_delta', text: 'Hi' },
+    });
+  });
+
+  test('multiple empty-data events interleaved with valid events', async () => {
+    async function* body(): AsyncGenerator<Buffer> {
+      // valid message_start
+      yield Buffer.from('event: message_start\n');
+      yield Buffer.from('data: {"type":"message_start","message":{"id":"msg_1"}}\n');
+      yield Buffer.from('\n');
+      // empty content_block_start (skip)
+      yield Buffer.from('event: content_block_start\n');
+      yield Buffer.from('\n');
+      // empty content_block_delta (skip)
+      yield Buffer.from('event: content_block_delta\n');
+      yield Buffer.from('\n');
+      // valid content_block_delta
+      yield Buffer.from('event: content_block_delta\n');
+      yield Buffer.from('data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"OK"}}\n');
+      yield Buffer.from('\n');
+      // empty message_stop (skip)
+      yield Buffer.from('event: message_stop\n');
+      yield Buffer.from('\n');
+    }
+
+    const stream = Stream.fromSSEResponse(
+      new Response(ReadableStreamFrom(body())),
+      new AbortController(),
+    );
+
+    const items = await collect(stream);
+    expect(items).toHaveLength(2);
+    expect(items[0]).toEqual({ type: 'message_start', message: { id: 'msg_1' } });
+    expect(items[1]).toEqual({
+      type: 'content_block_delta',
+      index: 0,
+      delta: { type: 'text_delta', text: 'OK' },
+    });
+  });
+
+  // -- Full realistic stream with some empty events --
+
+  test('realistic stream with empty events from edge environment', async () => {
+    async function* body(): AsyncGenerator<Buffer> {
+      // Simulate what Vercel Edge / Cloudflare Workers might produce:
+      // Some events arrive correctly, others lose their data due to chunking
+
+      yield Buffer.from('event: message_start\n');
+      yield Buffer.from('data: {"type":"message_start","message":{"id":"msg_test","type":"message","role":"assistant","content":[],"model":"claude-3-5-sonnet-20241022","stop_reason":null}}\n');
+      yield Buffer.from('\n');
+
+      yield Buffer.from('event: content_block_start\n');
+      yield Buffer.from('data: {"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}}\n');
+      yield Buffer.from('\n');
+
+      // Empty delta from network split
+      yield Buffer.from('event: content_block_delta\n');
+      yield Buffer.from('\n');
+
+      // Valid delta
+      yield Buffer.from('event: content_block_delta\n');
+      yield Buffer.from('data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"Hello"}}\n');
+      yield Buffer.from('\n');
+
+      yield Buffer.from('event: content_block_stop\n');
+      yield Buffer.from('data: {"type":"content_block_stop","index":0}\n');
+      yield Buffer.from('\n');
+
+      // Empty message_delta from network split
+      yield Buffer.from('event: message_delta\n');
+      yield Buffer.from('\n');
+
+      yield Buffer.from('event: message_stop\n');
+      yield Buffer.from('data: {"type":"message_stop"}\n');
+      yield Buffer.from('\n');
+    }
+
+    const stream = Stream.fromSSEResponse(
+      new Response(ReadableStreamFrom(body())),
+      new AbortController(),
+    );
+
+    const items = await collect(stream);
+    // Should have 5 valid events (2 empty ones skipped)
+    expect(items).toHaveLength(5);
+    expect(items.map((i: any) => i.type)).toEqual([
+      'message_start',
+      'content_block_start',
+      'content_block_delta',
+      'content_block_stop',
+      'message_stop',
+    ]);
+  });
+
+  // -- Ping events still work --
+
+  test('ping events with empty data are handled correctly', async () => {
+    async function* body(): AsyncGenerator<Buffer> {
+      yield Buffer.from('event: ping\n');
+      yield Buffer.from('\n');
+      yield Buffer.from('event: content_block_delta\n');
+      yield Buffer.from('data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"Hi"}}\n');
+      yield Buffer.from('\n');
+    }
+
+    const stream = Stream.fromSSEResponse(
+      new Response(ReadableStreamFrom(body())),
+      new AbortController(),
+    );
+
+    const items = await collect(stream);
+    expect(items).toHaveLength(1);
+    expect((items[0] as any).type).toBe('content_block_delta');
+  });
+
+  // -- Error events still work correctly --
+
+  test('error event with empty data still throws', async () => {
+    async function* body(): AsyncGenerator<Buffer> {
+      yield Buffer.from('event: error\n');
+      yield Buffer.from('data: {"type":"error","error":{"type":"api_error","message":"test"}}\n');
+      yield Buffer.from('\n');
+    }
+
+    const stream = Stream.fromSSEResponse(
+      new Response(ReadableStreamFrom(body())),
+      new AbortController(),
+    );
+
+    await expect(collect(stream)).rejects.toBeInstanceOf(APIError);
+  });
+
+  test('error event with empty data throws with empty message', async () => {
+    async function* body(): AsyncGenerator<Buffer> {
+      yield Buffer.from('event: error\n');
+      yield Buffer.from('\n');
+    }
+
+    const stream = Stream.fromSSEResponse(
+      new Response(ReadableStreamFrom(body())),
+      new AbortController(),
+    );
+
+    await expect(collect(stream)).rejects.toBeInstanceOf(APIError);
+  });
+
+  // -- Abort / break still works with empty events --
+
+  test('abort controller works mid-stream with empty events', async () => {
+    const controller = new AbortController();
+
+    async function* body(): AsyncGenerator<Buffer> {
+      yield Buffer.from('event: content_block_delta\n');
+      yield Buffer.from('\n'); // empty, skipped
+      yield Buffer.from('event: content_block_delta\n');
+      yield Buffer.from('data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"A"}}\n');
+      yield Buffer.from('\n');
+      // Simulate more data that won't be consumed
+      yield Buffer.from('event: content_block_delta\n');
+      yield Buffer.from('data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"B"}}\n');
+      yield Buffer.from('\n');
+    }
+
+    const stream = Stream.fromSSEResponse(
+      new Response(ReadableStreamFrom(body())),
+      controller,
+    );
+
+    // Abort should not crash the stream even when empty events are present.
+    // Note: due to async buffering, the stream may process events that were
+    // already yielded before the abort signal propagates.
+    const items: any[] = [];
+    for await (const item of stream) {
+      items.push(item);
+      if (items.length >= 1) {
+        controller.abort();
+      }
+    }
+
+    // At minimum, the first valid event was received; the stream did not crash
+    expect(items.length).toBeGreaterThanOrEqual(1);
+    expect(items[0].delta.text).toBe('A');
+  });
+
+  // -- Stream with only empty events --
+
+  test('stream with only empty events completes without error', async () => {
+    async function* body(): AsyncGenerator<Buffer> {
+      yield Buffer.from('event: message_start\n');
+      yield Buffer.from('\n');
+      yield Buffer.from('event: content_block_start\n');
+      yield Buffer.from('\n');
+      yield Buffer.from('event: content_block_delta\n');
+      yield Buffer.from('\n');
+      yield Buffer.from('event: content_block_stop\n');
+      yield Buffer.from('\n');
+      yield Buffer.from('event: message_stop\n');
+      yield Buffer.from('\n');
+    }
+
+    const stream = Stream.fromSSEResponse(
+      new Response(ReadableStreamFrom(body())),
+      new AbortController(),
+    );
+
+    const items = await collect(stream);
+    expect(items).toHaveLength(0);
+  });
+
+  // -- Many rapid events (stress test) --
+
+  test('handles many events with intermittent empty data (stress)', async () => {
+    const count = 100;
+    async function* body(): AsyncGenerator<Buffer> {
+      yield Buffer.from('event: message_start\n');
+      yield Buffer.from('data: {"type":"message_start","message":{"id":"msg_stress"}}\n');
+      yield Buffer.from('\n');
+
+      for (let i = 0; i < count; i++) {
+        if (i % 3 === 0) {
+          // Every 3rd event has empty data
+          yield Buffer.from('event: content_block_delta\n');
+          yield Buffer.from('\n');
+        } else {
+          yield Buffer.from('event: content_block_delta\n');
+          yield Buffer.from(`data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"${i}"}}\n`);
+          yield Buffer.from('\n');
+        }
+      }
+
+      yield Buffer.from('event: message_stop\n');
+      yield Buffer.from('data: {"type":"message_stop"}\n');
+      yield Buffer.from('\n');
+    }
+
+    const stream = Stream.fromSSEResponse(
+      new Response(ReadableStreamFrom(body())),
+      new AbortController(),
+    );
+
+    const items = await collect(stream);
+    // message_start + non-empty deltas + message_stop
+    // Non-empty: count - Math.ceil(count/3) = 100 - 34 = 66
+    const expectedDeltas = count - Math.ceil(count / 3);
+    expect(items).toHaveLength(1 + expectedDeltas + 1); // message_start + deltas + message_stop
+  });
+});


### PR DESCRIPTION
## Human View

### Problem

In edge and cloud environments (Vercel Edge, Cloudflare Workers, AWS Lambda@Edge), network proxies and CDNs can split SSE chunks so that an event line (`event: content_block_delta`) arrives without its corresponding `data:` line. The `SSEDecoder` correctly produces a `ServerSentEvent` with `data: ''`, but `Stream.fromSSEResponse` crashes with:

```
SyntaxError: Unexpected end of JSON input
    at (src/core/streaming.ts)
```

when it calls `JSON.parse('')` on the empty data.

This is a regression of #292 (originally fixed in v0.17.0 via #312 for `LineDecoder`). The root cause is different: the `LineDecoder` fix ensured correct line splitting, but `Stream.fromSSEResponse` never had a guard against empty data in the event handlers.

#### Impact
- Streams crash and abort in edge/cloud environments
- Users see `"Unexpected end of JSON input"` errors
- Workaround requires `@ts-ignore` or custom patching
- Reported across Vercel Edge, Cloudflare Workers, and various cloud Node.js deployments

### Root Cause

`SSEDecoder.decode()` accumulates data from `data:` lines and joins them with `\n`. When an event has no `data:` line, `this.data` is `[]`, and `[].join('\n')` produces `''` (empty string). `Stream.fromSSEResponse` then blindly calls `JSON.parse('')` for known event types (`completion`, `message_start`, `content_block_delta`, etc.), which throws.

#### Why PR #861 doesn't fix this

The existing PR #861 checks `sse.data == null`, but `SSEDecoder` always sets `data` to a string value. For events without data, `data` is `''` (empty string), and `'' == null` evaluates to `false` in JavaScript. The check never triggers.

### Fix

Added an empty-data guard (`if (!sse.data) continue`) before `JSON.parse()` for all event types that expect JSON data:
- `completion`
- `message_start`, `message_delta`, `message_stop`
- `content_block_start`, `content_block_delta`, `content_block_stop`

The falsy check `!sse.data` correctly catches both empty strings (`''`) and theoretically null/undefined values. Events with empty data are silently skipped, allowing the stream to continue processing subsequent valid events.

### Tests Added (16 new tests)

| Test | Description |
|------|-------------|
| **Per-event-type** (7 tests) | Each Anthropic event type with empty data is skipped without crashing |
| **Stream continuation** | Valid events are processed after empty-data events |
| **Interleaved events** | Mix of valid and empty-data events produces correct output |
| **Realistic edge simulation** | Full message lifecycle with empty events from network splits |
| **Ping handling** | Ping events with empty data still work correctly |
| **Error events** (2 tests) | Error events with/without data still throw `APIError` |
| **Abort controller** | Abort works correctly when empty events are present |
| **All-empty stream** | Stream with only empty events completes without error |
| **Stress test** | 100 events with every 3rd having empty data — all handled correctly |

All 26 streaming tests pass (10 pre-existing + 16 new).

### Checklist

- [x] Fix applied to both `completion` and message event handlers
- [x] Correctly uses falsy check (`!sse.data`) instead of null check (`== null`)
- [x] Does not modify `SSEDecoder` behavior (SSE spec compliance preserved)
- [x] Error events continue to throw `APIError` as expected
- [x] All pre-existing tests still pass
- [x] 16 new tests cover all event types, edge cases, and stress scenarios

Fixes #292 (regression). Supersedes #861.

---

## AI View (DCCE Protocol v1.0)

### Metadata
- **Generator**: Claude (Anthropic) via Cursor IDE
- **Methodology**: AI-assisted development with human oversight and review

### AI Contribution Summary
- Root cause analysis through code tracing
- Solution design and implementation
- Test development (16 new test cases)
- Edge case analysis and verification

### Verification Steps Performed
1. Reproduced the reported issue
2. Analyzed source code to identify root cause
3. Implemented and tested the fix

### Human Review Guidance
- Verify the root cause analysis matches your understanding of the codebase
- Core changes are in: `this.data`
- Verify edge case coverage is complete

Made with M7 [Cursor](https://cursor.com)
