### PR TITLE
fix(tool runner): don't exit early on pause_turn

### DIFF
--- a/.stats.yml
+++ b/.stats.yml
@@ -1,4 +1,4 @@
 configured_endpoints: 34
 openapi_spec_url: https://storage.googleapis.com/stainless-sdk-openapi-specs/anthropic%2Fanthropic-fee5dc365a4948e68639582c5301d4d0666c7d85a11628d7917e1477f76d3da1.yml
 openapi_spec_hash: d5543958074cd2bd74096cd69f3bb4f9
-config_hash: c4802b6c7f8ffae62f7d73b2ac61e635
+config_hash: 8739bb23213865e8ad45a32ba99a4de1

--- a/src/lib/tools/BetaToolRunner.ts
+++ b/src/lib/tools/BetaToolRunner.ts
@@ -213,8 +213,11 @@ export class BetaToolRunner<Stream extends boolean> {
             const toolMessage = await this.#generateToolResponse(this.#state.params.messages.at(-1)!);
             if (toolMessage) {
               this.#state.params.messages.push(toolMessage);
-            } else if (!this.#mutated) {
-              break;
+            } else {
+              const message = await this.#message;
+              if (!this.#mutated && message.stop_reason !== 'pause_turn') {
+                break;
+              }
             }
           }
         } finally {


### PR DESCRIPTION
## Problem
The tool runner was exiting early when encountering a `pause_turn` stop reason, preventing it from continuing the conversation loop.

`pause_turn` means the API paused some operation and wants the client to send back the message to continue it, which is why we should send it back instead of just exiting the loop.