### PR TITLE
fix: throw-error-when-docx-pptx-failed

### DIFF
--- a/src/lib/BetaMessageStream.ts
+++ b/src/lib/BetaMessageStream.ts
@@ -520,6 +520,14 @@ export class BetaMessageStream<ParsedT = null> implements AsyncIterable<BetaMess
       throw new AnthropicError(`request ended without sending any chunks`);
     }
     this.#currentMessageSnapshot = undefined;
+    // If stop_reason is null, the stream was interrupted before receiving a
+    // terminal event (message_delta with stop_reason). This typically indicates
+    // a server-side error that caused the stream to close prematurely.
+    if (snapshot.stop_reason == null) {
+      throw new AnthropicError(
+        'stream ended without receiving a terminal event; the response may be incomplete due to a server-side error',
+      );
+    }
     return maybeParseBetaMessage(snapshot, this.#params, { logger: this.#logger });
   }
 

--- a/src/lib/BetaMessageStream.ts
+++ b/src/lib/BetaMessageStream.ts
@@ -525,7 +525,7 @@ export class BetaMessageStream<ParsedT = null> implements AsyncIterable<BetaMess
     // a server-side error that caused the stream to close prematurely.
     if (snapshot.stop_reason == null) {
       throw new AnthropicError(
-        'stream ended without receiving a terminal event; the response may be incomplete due to a server-side error',
+        'Stream ended without receiving a terminal event; the response may be incomplete due to a server-side error',
       );
     }
     return maybeParseBetaMessage(snapshot, this.#params, { logger: this.#logger });

--- a/src/lib/MessageStream.ts
+++ b/src/lib/MessageStream.ts
@@ -524,7 +524,7 @@ export class MessageStream<ParsedT = null> implements AsyncIterable<MessageStrea
     // a server-side error that caused the stream to close prematurely.
     if (snapshot.stop_reason == null) {
       throw new AnthropicError(
-        'stream ended without receiving a terminal event; the response may be incomplete due to a server-side error',
+        'Stream ended without receiving a terminal event; the response may be incomplete due to a server-side error',
       );
     }
     return maybeParseMessage(snapshot, this.#params, { logger: this.#logger });

--- a/src/lib/MessageStream.ts
+++ b/src/lib/MessageStream.ts
@@ -519,6 +519,14 @@ export class MessageStream<ParsedT = null> implements AsyncIterable<MessageStrea
       throw new AnthropicError(`request ended without sending any chunks`);
     }
     this.#currentMessageSnapshot = undefined;
+    // If stop_reason is null, the stream was interrupted before receiving a
+    // terminal event (message_delta with stop_reason). This typically indicates
+    // a server-side error that caused the stream to close prematurely.
+    if (snapshot.stop_reason == null) {
+      throw new AnthropicError(
+        'stream ended without receiving a terminal event; the response may be incomplete due to a server-side error',
+      );
+    }
     return maybeParseMessage(snapshot, this.#params, { logger: this.#logger });
   }
 

--- a/tests/api-resources/MessageStream.test.ts
+++ b/tests/api-resources/MessageStream.test.ts
@@ -292,7 +292,7 @@ describe('MessageStream class', () => {
     });
 
     await expect(stream.done()).rejects.toThrow(
-      'stream ended without receiving a terminal event; the response may be incomplete due to a server-side error',
+      'Stream ended without receiving a terminal event; the response may be incomplete due to a server-side error',
     );
   });
 

--- a/tests/api-resources/MessageStream.test.ts
+++ b/tests/api-resources/MessageStream.test.ts
@@ -1,4 +1,4 @@
-import Anthropic, { APIConnectionError, APIUserAbortError } from '@anthropic-ai/sdk';
+import Anthropic, { AnthropicError, APIConnectionError, APIUserAbortError } from '@anthropic-ai/sdk';
 import { Message, MessageStreamEvent } from '@anthropic-ai/sdk/resources/messages';
 import { mockFetch } from '../lib/mock-fetch';
 import { loadFixture, parseSSEFixture } from '../lib/sse-helpers';
@@ -224,6 +224,76 @@ describe('MessageStream class', () => {
 
     assertToolUseResponse(events, finalMessage);
     expect(finalText).toBe("I'll check the current weather in Paris for you.");
+  });
+
+  it('throws error when stream ends without message_stop', async () => {
+    const { fetch, handleStreamEvents } = mockFetch();
+
+    const anthropic = new Anthropic({ apiKey: '...', fetch });
+
+    // Send message_start + content blocks but omit message_delta and message_stop
+    const truncatedEvents = [
+      {
+        type: 'message_start',
+        message: {
+          id: 'msg_truncated',
+          type: 'message',
+          role: 'assistant',
+          content: [],
+          model: 'claude-opus-4-20250514',
+          stop_reason: null,
+          stop_sequence: null,
+          usage: { input_tokens: 11, output_tokens: 1 },
+        },
+      },
+      { type: 'content_block_start', index: 0, content_block: { type: 'text', text: '' } },
+      { type: 'content_block_delta', index: 0, delta: { type: 'text_delta', text: 'Hello' } },
+      { type: 'content_block_stop', index: 0 },
+    ];
+    handleStreamEvents(truncatedEvents);
+
+    const stream = anthropic.messages.stream({
+      max_tokens: 1024,
+      model: 'claude-opus-4-20250514',
+      messages: [{ role: 'user', content: 'Say hello there!' }],
+    });
+
+    await expect(stream.done()).rejects.toThrow(AnthropicError);
+    await expect(stream.finalMessage()).rejects.toThrow(/terminal event/);
+  });
+
+  it('throws error when stream ends after message_start only', async () => {
+    const { fetch, handleStreamEvents } = mockFetch();
+
+    const anthropic = new Anthropic({ apiKey: '...', fetch });
+
+    // Send only message_start, then end the stream
+    const truncatedEvents = [
+      {
+        type: 'message_start',
+        message: {
+          id: 'msg_truncated_2',
+          type: 'message',
+          role: 'assistant',
+          content: [],
+          model: 'claude-opus-4-20250514',
+          stop_reason: null,
+          stop_sequence: null,
+          usage: { input_tokens: 11, output_tokens: 1 },
+        },
+      },
+    ];
+    handleStreamEvents(truncatedEvents);
+
+    const stream = anthropic.messages.stream({
+      max_tokens: 1024,
+      model: 'claude-opus-4-20250514',
+      messages: [{ role: 'user', content: 'Say hello there!' }],
+    });
+
+    await expect(stream.done()).rejects.toThrow(
+      'stream ended without receiving a terminal event; the response may be incomplete due to a server-side error',
+    );
   });
 
   it('does not throw unhandled rejection with withResponse()', async () => {


### PR DESCRIPTION
I fixed an issue where the server would silently fail if it closed the SSE stream without sending message_stop.Now in endRequest() for both MessageStream and BetaMessageStream, I added a stop_reason null check. If stop_reason is missing, it throws a clear, descriptive error instead of resolving with an incomplete message.

for #893 