### PR TITLE
perf(messagestream): optimize parsing performance with lazy getter  (Issue #933)

### DIFF
--- a/src/lib/MessageStream.ts
+++ b/src/lib/MessageStream.ts
@@ -637,7 +637,13 @@ export class MessageStream<ParsedT = null> implements AsyncIterable<MessageStrea
               });
 
               if (jsonBuf) {
-                newContent.input = partialParse(jsonBuf);
+                Object.defineProperty(newContent, 'input', {
+                  get() {
+                    return partialParse(this[JSON_BUF_PROPERTY]);
+                  },
+                  enumerable: true,
+                  configurable: true,
+                });
               }
               snapshot.content[event.index] = newContent;
             }


### PR DESCRIPTION
 Converted `content.input` in `MessageStream` to a lazy getter. Previously, the SDK re-parsed the entire JSON buffer on every delta, leading to O(N²) complexity. This change ensures parsing only happens when needed, drastically improving responsiveness for large streaming responses.
 
 Closes #933