### PR TITLE
fix: shallow copy content_block in BetaMessageStream#accumulateMessage

### DIFF
--- a/src/lib/BetaMessageStream.ts
+++ b/src/lib/BetaMessageStream.ts
@@ -603,7 +603,7 @@ export class BetaMessageStream<ParsedT = null> implements AsyncIterable<BetaMess
 
         return snapshot;
       case 'content_block_start':
-        snapshot.content.push(event.content_block);
+        snapshot.content.push({ ...event.content_block });
         return snapshot;
       case 'content_block_delta': {
         const snapshotContent = snapshot.content.at(event.index);


### PR DESCRIPTION
## Summary

- **Fix missing defensive copy in `BetaMessageStream`**: The `content_block_start` case in `BetaMessageStream#accumulateMessage` pushes `event.content_block` directly into the snapshot's content array, while the non-beta `MessageStream` correctly uses `{ ...event.content_block }` to create a shallow copy.

## Details

In `src/lib/MessageStream.ts` (line 600):
```typescript
case 'content_block_start':
    snapshot.content.push({ ...event.content_block }); // ✅ shallow copy
    return snapshot;
```

In `src/lib/BetaMessageStream.ts` (line 606, before this fix):
```typescript
case 'content_block_start':
    snapshot.content.push(event.content_block); // ❌ direct reference
    return snapshot;
```

Without the copy, the snapshot holds a direct reference to the event object. Any external code that retains and mutates the original event's `content_block` would inadvertently corrupt the accumulated message snapshot. The rest of the `content_block_delta` handling in both files already creates new objects via spread (`{ ...snapshotContent, ... }`), so this is specifically a gap in the `content_block_start` case of the beta stream.

This is a one-character fix (`{ ...event.content_block }` instead of `event.content_block`) that aligns `BetaMessageStream` with the existing `MessageStream` behavior.

## Test plan

- [ ] Verify existing tests pass
- [ ] The fix is a minimal change that matches the pattern already used in `MessageStream`
- [ ] All subsequent `content_block_delta` handlers already create new objects via spread, so this only affects the initial content block reference

🤖 Generated with [Claude Code](https://claude.com/claude-code)