### PR TITLE
perf: lazy-parse partial JSON in MessageStream to avoid O(N²)

### DIFF
--- a/src/lib/MessageStream.ts
+++ b/src/lib/MessageStream.ts
@@ -637,7 +637,26 @@ export class MessageStream<ParsedT = null> implements AsyncIterable<MessageStrea
               });
 
               if (jsonBuf) {
-                newContent.input = partialParse(jsonBuf);
+                // Use a lazy getter so partialParse is only called when
+                // .input is actually accessed, avoiding O(N²) re-parsing
+                // when consumers don't need intermediate snapshots.
+                let cachedInput: unknown;
+                let inputParsed = false;
+                Object.defineProperty(newContent, 'input', {
+                  get() {
+                    if (!inputParsed) {
+                      cachedInput = partialParse(jsonBuf);
+                      inputParsed = true;
+                    }
+                    return cachedInput;
+                  },
+                  set(value: unknown) {
+                    cachedInput = value;
+                    inputParsed = true;
+                  },
+                  enumerable: true,
+                  configurable: true,
+                });
               }
               snapshot.content[event.index] = newContent;
             }


### PR DESCRIPTION
## Problem

During structured output streaming, `MessageStream` eagerly calls `partialParse(jsonBuf)` on every `input_json_delta` event to populate `content.input`. Since `jsonBuf` grows linearly with each delta, and `partialParse` is O(N) in the buffer length, the total cost over N deltas is **O(N²)**. This causes high CPU usage and UI freezing for long structured outputs.

## Fix

Replace the eager assignment:
```typescript
newContent.input = partialParse(jsonBuf);  // called on every delta
```

With a lazy cached getter:
```typescript
Object.defineProperty(newContent, 'input', {
  get() {
    if (!inputParsed) {
      cachedInput = partialParse(jsonBuf);
      inputParsed = true;
    }
    return cachedInput;
  },
  // ...
});
```

### Behavior

| Scenario | Before | After |
|----------|--------|-------|
| Consumer reads final `.input` only | O(N²) total parses | O(N) single parse |
| Consumer listens to `inputJson` events | O(N²) | O(N²)* but cached per delta |
| Consumer never reads `.input` | O(N²) wasted | Zero parses |

\* When a consumer explicitly subscribes to every `inputJson` event, the per-delta parse is inherent to their use case.

### Backward Compatibility

- `content.input` still returns the same parsed object
- The `inputJson` event still fires with the correct snapshot
- The getter is enumerable and configurable, matching the original property semantics
- A setter is included so direct assignment (`content.input = ...`) still works

## Changes

- **`src/lib/MessageStream.ts`**: Replaced eager `partialParse` call with a lazy cached getter on `content.input`

Fixes #933