### PR TITLE
fix: release stream state on end to prevent memory leaks

### DIFF
--- a/src/lib/BetaMessageStream.ts
+++ b/src/lib/BetaMessageStream.ts
@@ -404,6 +404,14 @@ export class BetaMessageStream<ParsedT = null> implements AsyncIterable<BetaMess
       // Release large internal state to prevent memory leaks when stream references
       // are retained (e.g. in long-running tool loops). The final message is preserved
       // in #cachedFinalMessage so finalMessage() / finalText() continue to work.
+      //
+      // Behavioral notes for callers:
+      // - 'abort' cannot fire after 'end': the `if (this.#ended) return` guard at the
+      //   top of this method prevents any further events once end has fired.
+      // - 'end' listeners that read `receivedMessages` directly will see an empty array.
+      //   Use `finalMessage()` instead, which reads from #cachedFinalMessage.
+      // - `messages` (the input params array) is also cleared. Post-end access to
+      //   `messages` is no longer supported; it too can hold O(n²) data across turns.
       this.messages.length = 0;
       this.receivedMessages.length = 0;
       this.#currentMessageSnapshot = undefined;

--- a/src/lib/BetaMessageStream.ts
+++ b/src/lib/BetaMessageStream.ts
@@ -55,6 +55,7 @@ export class BetaMessageStream<ParsedT = null> implements AsyncIterable<BetaMess
   messages: BetaMessageParam[] = [];
   receivedMessages: ParsedBetaMessage<ParsedT>[] = [];
   #currentMessageSnapshot: BetaMessage | undefined;
+  #cachedFinalMessage: ParsedBetaMessage<ParsedT> | undefined;
   #params: MessageCreateParams | null = null;
 
   controller: AbortController = new AbortController();
@@ -320,6 +321,9 @@ export class BetaMessageStream<ParsedT = null> implements AsyncIterable<BetaMess
   }
 
   #getFinalMessage(): ParsedBetaMessage<ParsedT> {
+    if (this.#cachedFinalMessage) {
+      return this.#cachedFinalMessage;
+    }
     if (this.receivedMessages.length === 0) {
       throw new AnthropicError('stream ended without producing a Message with role=assistant');
     }
@@ -337,12 +341,9 @@ export class BetaMessageStream<ParsedT = null> implements AsyncIterable<BetaMess
   }
 
   #getFinalText(): string {
-    if (this.receivedMessages.length === 0) {
-      throw new AnthropicError('stream ended without producing a Message with role=assistant');
-    }
-    const textBlocks = this.receivedMessages
-      .at(-1)!
-      .content.filter((block): block is BetaTextBlock => block.type === 'text')
+    const finalMessage = this.#getFinalMessage();
+    const textBlocks = finalMessage.content
+      .filter((block): block is BetaTextBlock => block.type === 'text')
       .map((block) => block.text);
     if (textBlocks.length === 0) {
       throw new AnthropicError('stream ended without producing a content block with type=text');
@@ -399,6 +400,18 @@ export class BetaMessageStream<ParsedT = null> implements AsyncIterable<BetaMess
       listeners.forEach(({ listener }: any) => listener(...args));
     }
 
+    if (event === 'end') {
+      // Release large internal state to prevent memory leaks when stream references
+      // are retained (e.g. in long-running tool loops). The final message is preserved
+      // in #cachedFinalMessage so finalMessage() / finalText() continue to work.
+      this.messages.length = 0;
+      this.receivedMessages.length = 0;
+      this.#currentMessageSnapshot = undefined;
+      this.#params = null;
+      this.#listeners = {};
+      return;
+    }
+
     if (event === 'abort') {
       const error = args[0] as APIUserAbortError;
       if (!this.#catchingPromiseCreated && !listeners?.length) {
@@ -432,6 +445,7 @@ export class BetaMessageStream<ParsedT = null> implements AsyncIterable<BetaMess
   protected _emitFinal() {
     const finalMessage = this.receivedMessages.at(-1);
     if (finalMessage) {
+      this.#cachedFinalMessage = finalMessage;
       this._emit('finalMessage', this.#getFinalMessage());
     }
   }

--- a/src/lib/MessageStream.ts
+++ b/src/lib/MessageStream.ts
@@ -52,6 +52,7 @@ export class MessageStream<ParsedT = null> implements AsyncIterable<MessageStrea
   messages: MessageParam[] = [];
   receivedMessages: ParsedMessage<ParsedT>[] = [];
   #currentMessageSnapshot: Message | undefined;
+  #cachedFinalMessage: ParsedMessage<ParsedT> | undefined;
   #params: MessageCreateParams | null = null;
 
   controller: AbortController = new AbortController();
@@ -328,6 +329,9 @@ export class MessageStream<ParsedT = null> implements AsyncIterable<MessageStrea
   }
 
   #getFinalMessage(): ParsedMessage<ParsedT> {
+    if (this.#cachedFinalMessage) {
+      return this.#cachedFinalMessage;
+    }
     if (this.receivedMessages.length === 0) {
       throw new AnthropicError('stream ended without producing a Message with role=assistant');
     }
@@ -345,12 +349,9 @@ export class MessageStream<ParsedT = null> implements AsyncIterable<MessageStrea
   }
 
   #getFinalText(): string {
-    if (this.receivedMessages.length === 0) {
-      throw new AnthropicError('stream ended without producing a Message with role=assistant');
-    }
-    const textBlocks = this.receivedMessages
-      .at(-1)!
-      .content.filter((block): block is TextBlock => block.type === 'text')
+    const finalMessage = this.#getFinalMessage();
+    const textBlocks = finalMessage.content
+      .filter((block): block is TextBlock => block.type === 'text')
       .map((block) => block.text);
     if (textBlocks.length === 0) {
       throw new AnthropicError('stream ended without producing a content block with type=text');
@@ -407,6 +408,18 @@ export class MessageStream<ParsedT = null> implements AsyncIterable<MessageStrea
       listeners.forEach(({ listener }: any) => listener(...args));
     }
 
+    if (event === 'end') {
+      // Release large internal state to prevent memory leaks when stream references
+      // are retained (e.g. in long-running tool loops). The final message is preserved
+      // in #cachedFinalMessage so finalMessage() / finalText() continue to work.
+      this.messages.length = 0;
+      this.receivedMessages.length = 0;
+      this.#currentMessageSnapshot = undefined;
+      this.#params = null;
+      this.#listeners = {};
+      return;
+    }
+
     if (event === 'abort') {
       const error = args[0] as APIUserAbortError;
       if (!this.#catchingPromiseCreated && !listeners?.length) {
@@ -440,6 +453,7 @@ export class MessageStream<ParsedT = null> implements AsyncIterable<MessageStrea
   protected _emitFinal() {
     const finalMessage = this.receivedMessages.at(-1);
     if (finalMessage) {
+      this.#cachedFinalMessage = finalMessage;
       this._emit('finalMessage', this.#getFinalMessage());
     }
   }

--- a/src/lib/MessageStream.ts
+++ b/src/lib/MessageStream.ts
@@ -412,6 +412,14 @@ export class MessageStream<ParsedT = null> implements AsyncIterable<MessageStrea
       // Release large internal state to prevent memory leaks when stream references
       // are retained (e.g. in long-running tool loops). The final message is preserved
       // in #cachedFinalMessage so finalMessage() / finalText() continue to work.
+      //
+      // Behavioral notes for callers:
+      // - 'abort' cannot fire after 'end': the `if (this.#ended) return` guard at the
+      //   top of this method prevents any further events once end has fired.
+      // - 'end' listeners that read `receivedMessages` directly will see an empty array.
+      //   Use `finalMessage()` instead, which reads from #cachedFinalMessage.
+      // - `messages` (the input params array) is also cleared. Post-end access to
+      //   `messages` is no longer supported; it too can hold O(n²) data across turns.
       this.messages.length = 0;
       this.receivedMessages.length = 0;
       this.#currentMessageSnapshot = undefined;

--- a/tests/api-resources/MessageStream.test.ts
+++ b/tests/api-resources/MessageStream.test.ts
@@ -251,4 +251,105 @@ describe('MessageStream class', () => {
     });
     await expect(stream).rejects.toThrow(APIConnectionError);
   });
+
+  describe('state cleanup and caching after end', () => {
+    it('finalMessage() resolves via cache after receivedMessages is cleared', async () => {
+      const { fetch, handleStreamEvents } = mockFetch();
+      const anthropic = new Anthropic({ apiKey: '...', fetch });
+
+      const fixtureContent = loadFixture('basic_response.txt');
+      const streamEvents = await parseSSEFixture(fixtureContent);
+      handleStreamEvents(streamEvents);
+
+      const stream = anthropic.messages.stream({
+        max_tokens: 1024,
+        model: 'claude-opus-4-20250514',
+        messages: [{ role: 'user', content: 'Say hello there!' }],
+      });
+
+      await stream.done();
+
+      // receivedMessages is cleared after end — finalMessage() must use the cache
+      expect(stream.receivedMessages).toHaveLength(0);
+      const msg = await stream.finalMessage();
+      expect(msg).toMatchObject(EXPECTED_BASIC_MESSAGE);
+    });
+
+    it('finalText() resolves via cache after end fires', async () => {
+      const { fetch, handleStreamEvents } = mockFetch();
+      const anthropic = new Anthropic({ apiKey: '...', fetch });
+
+      const fixtureContent = loadFixture('basic_response.txt');
+      const streamEvents = await parseSSEFixture(fixtureContent);
+      handleStreamEvents(streamEvents);
+
+      const stream = anthropic.messages.stream({
+        max_tokens: 1024,
+        model: 'claude-opus-4-20250514',
+        messages: [{ role: 'user', content: 'Say hello there!' }],
+      });
+
+      await stream.done();
+      expect(await stream.finalText()).toBe('Hello there!');
+    });
+
+    it('clears receivedMessages and messages after end to prevent memory leaks', async () => {
+      const { fetch, handleStreamEvents } = mockFetch();
+      const anthropic = new Anthropic({ apiKey: '...', fetch });
+
+      const fixtureContent = loadFixture('basic_response.txt');
+      const streamEvents = await parseSSEFixture(fixtureContent);
+      handleStreamEvents(streamEvents);
+
+      const stream = anthropic.messages.stream({
+        max_tokens: 1024,
+        model: 'claude-opus-4-20250514',
+        messages: [{ role: 'user', content: 'Say hello there!' }],
+      });
+
+      // Capture array lengths from within the finalMessage listener (fires before end cleanup)
+      let messagesLengthBeforeCleanup = -1;
+      let receivedMessagesLengthBeforeCleanup = -1;
+      stream.on('finalMessage', () => {
+        messagesLengthBeforeCleanup = stream.messages.length;
+        receivedMessagesLengthBeforeCleanup = stream.receivedMessages.length;
+      });
+
+      await stream.done();
+
+      // Arrays were populated before cleanup fired
+      expect(messagesLengthBeforeCleanup).toBeGreaterThan(0);
+      expect(receivedMessagesLengthBeforeCleanup).toBeGreaterThan(0);
+
+      // Arrays are cleared after end fires
+      expect(stream.messages).toHaveLength(0);
+      expect(stream.receivedMessages).toHaveLength(0);
+    });
+
+    it('finalMessage listener receives message before arrays are cleared', async () => {
+      const { fetch, handleStreamEvents } = mockFetch();
+      const anthropic = new Anthropic({ apiKey: '...', fetch });
+
+      const fixtureContent = loadFixture('basic_response.txt');
+      const streamEvents = await parseSSEFixture(fixtureContent);
+      handleStreamEvents(streamEvents);
+
+      const stream = anthropic.messages.stream({
+        max_tokens: 1024,
+        model: 'claude-opus-4-20250514',
+        messages: [{ role: 'user', content: 'Say hello there!' }],
+      });
+
+      let messageInListener: Message | undefined;
+      stream.on('finalMessage', (msg) => {
+        messageInListener = msg;
+      });
+
+      await stream.done();
+
+      expect(messageInListener).toMatchObject(EXPECTED_BASIC_MESSAGE);
+      // Cache still works after end
+      expect(await stream.finalMessage()).toMatchObject(EXPECTED_BASIC_MESSAGE);
+    });
+  });
 });


### PR DESCRIPTION
## Summary

- `MessageStream` and `BetaMessageStream` accumulate all data in `messages` and `receivedMessages` arrays for the entire lifetime of the stream object
- When stream instances are retained after completion (e.g. in a long-running tool loop where the caller holds references to yielded streams), this causes unbounded memory growth
- The `BetaToolRunner` yields a new `BetaMessageStream` per iteration; if the caller retains all yielded streams, each holds a copy of the full message history at that point — O(n²) total

## Fix

Cache the final message in `_emitFinal()` (before the `'end'` event fires), then after all `'end'` listeners are called, clear:
- `messages` (copy of all API params — grows with conversation)
- `receivedMessages` (accumulates all API responses)
- `#currentMessageSnapshot`, `#params`, `#listeners`

`finalMessage()` and `finalText()` continue to work via `#cachedFinalMessage`.

## Observed impact

Claude Code sessions growing from 2GB → 20GB+ in a single session when using tool-heavy workflows. The process had to be restarted repeatedly due to OOM. The root cause was identified by extracting embedded JS from the Claude Code binary and tracing the retention chain:

1. `BetaToolRunner` yields a new `BetaMessageStream` per iteration
2. Claude Code pushes each yielded stream into a React ref that is never trimmed
3. Each retained stream holds `messages` (copy of all params at that iteration) + `receivedMessages`
4. Compaction reduces `params.messages` in the runner but old stream copies are unaffected

## Test plan

- [ ] Existing tests pass
- [ ] `finalMessage()` resolves correctly after `end`
- [ ] `finalText()` resolves correctly after `end`
- [ ] Stream event listeners (including `'end'` listeners) still fire before cleanup