### PR TITLE
fix: join text blocks with empty string in finalText

### DIFF
--- a/src/lib/MessageStream.ts
+++ b/src/lib/MessageStream.ts
@@ -355,7 +355,7 @@ export class MessageStream<ParsedT = null> implements AsyncIterable<MessageStrea
     if (textBlocks.length === 0) {
       throw new AnthropicError('stream ended without producing a content block with type=text');
     }
-    return textBlocks.join(' ');
+    return textBlocks.join('');
   }
 
   /**


### PR DESCRIPTION
## Summary

- Fixes `#getFinalText()` in `src/lib/MessageStream.ts` to join multiple text blocks with an empty string instead of a space

## Bug

`#getFinalText()` was calling `textBlocks.join(' ')`, which inserts an unexpected space character between text content blocks:

```ts
// Before (buggy)
return textBlocks.join(' ');   // "Hello world" with an extra space
```

When a response contains two adjacent text blocks (`"Hello"` and `" world"`), the result would be `"Hello  world"` (double space) instead of `"Hello world"`.

## Fix

```ts
// After (correct)
return textBlocks.join('');
```

This matches the Python SDK which uses `"".join(text_blocks)` (empty separator), and the docstring which says the blocks are *concatenated* (not space-joined).

## Test plan

- [x] Existing base64/MessageStream tests still pass
- [x] Consistent with Python SDK behaviour (`"".join(text_blocks)`)
- [x] Matches the JSDoc description: "concatenated together if there are more than one text blocks"

🤖 Generated with [Claude Code](https://claude.com/claude-code)