### PR TITLE
fix: prevent stack overflow in toBase64 for large Uint8Array inputs

### DIFF
--- a/src/internal/utils/base64.ts
+++ b/src/internal/utils/base64.ts
@@ -15,7 +15,14 @@ export const toBase64 = (data: string | Uint8Array | null | undefined): string =
   }
 
   if (typeof btoa !== 'undefined') {
-    return btoa(String.fromCharCode.apply(null, data as any));
+    // Process in chunks to avoid a RangeError ("Maximum call stack size exceeded")
+    // when spreading large Uint8Arrays as arguments to String.fromCharCode.apply().
+    const CHUNK_SIZE = 8192;
+    let binary = '';
+    for (let i = 0; i < data.length; i += CHUNK_SIZE) {
+      binary += String.fromCharCode.apply(null, data.subarray(i, i + CHUNK_SIZE) as any);
+    }
+    return btoa(binary);
   }
 
   throw new AnthropicError('Cannot generate base64 string; Expected `Buffer` or `btoa` to be defined');


### PR DESCRIPTION
## Summary

`toBase64()` in `src/internal/utils/base64.ts` called `String.fromCharCode.apply(null, data)` on the entire input array at once. When `data` is a large `Uint8Array` (e.g. for large image payloads), this spreads every element as a function argument, causing a `RangeError: Maximum call stack size exceeded` in V8 and other JS engines.

The fix processes the array in 8192-byte chunks, which is the standard approach for this pattern.

## Changes

- `src/internal/utils/base64.ts`: Process `Uint8Array` in 8192-byte chunks inside `toBase64()` to avoid stack overflow

## Test plan

- [ ] Verify `toBase64()` works correctly for inputs larger than ~65KB (previously would throw `RangeError`)
- [ ] Verify output is identical to the unchunked version for small inputs

🤖 Generated with [Claude Code](https://claude.com/claude-code)