### PR TITLE
docs: fix broken compare links in CHANGELOG files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -680,7 +680,7 @@ Full Changelog: [sdk-v0.50.0...sdk-v0.50.1](https://github.com/anthropics/anthro
 
 ## 0.50.0 (2025-05-09)
 
-Full Changelog: [sdk-v0.41.0...sdk-v0.50.0](https://github.com/anthropics/anthropic-sdk-typescript/compare/sdk-v0.41.0...sdk-v0.42.0)
+Full Changelog: [sdk-v0.41.0...sdk-v0.50.0](https://github.com/anthropics/anthropic-sdk-typescript/compare/sdk-v0.41.0...sdk-v0.50.0)
 
 ### Features
 
@@ -1790,7 +1790,7 @@ Full Changelog: [sdk-v0.12.4...sdk-v0.12.5](https://github.com/anthropics/anthro
 
 ## 0.12.4 (2024-01-23)
 
-Full Changelog: [sdk-v0.12.3...sdk-v0.12.4](https://github.com/anthropics/anthropic-sdk-typescript/compare/sdk-v0.12.3...sdk-v0.12.4)
+Full Changelog: [v0.12.3...sdk-v0.12.4](https://github.com/anthropics/anthropic-sdk-typescript/compare/v0.12.3...sdk-v0.12.4)
 
 ### Chores
 

--- a/packages/bedrock-sdk/CHANGELOG.md
+++ b/packages/bedrock-sdk/CHANGELOG.md
@@ -138,7 +138,7 @@ Full Changelog: [bedrock-sdk-v0.21.0...bedrock-sdk-v0.21.1](https://github.com/a
 
 ## 0.21.0 (2025-05-09)
 
-Full Changelog: [bedrock-sdk-v0.20.0...bedrock-sdk-v0.21.0](https://github.com/anthropics/anthropic-sdk-typescript/compare/bedrock-sdk-v0.20.0...bedrock-sdk-v0.21.0)
+Full Changelog: [bedrock-sdk-v0.12.7...bedrock-sdk-v0.21.0](https://github.com/anthropics/anthropic-sdk-typescript/compare/bedrock-sdk-v0.12.7...bedrock-sdk-v0.21.0)
 
 ### Features
 

--- a/packages/foundry-sdk/CHANGELOG.md
+++ b/packages/foundry-sdk/CHANGELOG.md
@@ -27,7 +27,7 @@ Full Changelog: [foundry-sdk-v0.2.0...foundry-sdk-v0.2.1](https://github.com/ant
 
 ## 0.2.0 (2025-11-18)
 
-Full Changelog: [foundry-sdk-v0.1.0...foundry-sdk-v0.2.0](https://github.com/anthropics/anthropic-sdk-typescript/compare/foundry-sdk-v0.1.0...foundry-sdk-v0.2.0)
+Full Changelog: [foundry-sdk-v0.2.0](https://github.com/anthropics/anthropic-sdk-typescript/releases/tag/foundry-sdk-v0.2.0)
 
 ### Features
 

--- a/packages/vertex-sdk/CHANGELOG.md
+++ b/packages/vertex-sdk/CHANGELOG.md
@@ -150,7 +150,7 @@ Full Changelog: [vertex-sdk-v0.10.0...vertex-sdk-v0.11.0](https://github.com/ant
 
 ## 0.10.0 (2025-05-09)
 
-Full Changelog: [vertex-sdk-v0.7.0...vertex-sdk-v0.7.1](https://github.com/anthropics/anthropic-sdk-typescript/compare/vertex-sdk-v0.7.0...vertex-sdk-v0.7.1)
+Full Changelog: [vertex-sdk-v0.7.1...vertex-sdk-v0.11.0](https://github.com/anthropics/anthropic-sdk-typescript/compare/vertex-sdk-v0.7.1...vertex-sdk-v0.11.0)
 
 ### Bug Fixes
 
@@ -389,7 +389,7 @@ Full Changelog: [vertex-sdk-v0.1.0...vertex-sdk-v0.1.1](https://github.com/anthr
 
 ## 0.1.0 (2024-01-23)
 
-Full Changelog: [vertex-sdk-v0.0.1...vertex-sdk-v0.1.0](https://github.com/anthropics/anthropic-sdk-typescript/compare/vertex-sdk-v0.0.1...vertex-sdk-v0.1.0)
+Full Changelog: [vertex-sdk-v0.1.0](https://github.com/anthropics/anthropic-sdk-typescript/releases/tag/vertex-sdk-v0.1.0)
 
 ### Features
 


### PR DESCRIPTION
Fixes #875

Several compare links across CHANGELOG files referenced non-existent tags, producing 404 errors on GitHub.

**Root CHANGELOG.md:**
- v0.50.0: URL pointed to `sdk-v0.42.0` (doesn't exist) — corrected to `sdk-v0.41.0...sdk-v0.50.0`
- v0.12.4: `sdk-v0.12.3` tag doesn't exist (uses `v0.12.3` prefix) — updated to `v0.12.3...sdk-v0.12.4`

**packages/vertex-sdk/CHANGELOG.md:**
- v0.10.0: Linked to `v0.7.0...v0.7.1` (wrong range, no v0.10.0 tag) — corrected to `v0.7.1...v0.11.0`
- v0.1.0: `vertex-sdk-v0.0.1` tag doesn't exist — linked to release tag (initial release)

**packages/bedrock-sdk/CHANGELOG.md:**
- v0.21.0: `bedrock-sdk-v0.20.0` tag doesn't exist — corrected to `v0.12.7...v0.21.0`

**packages/foundry-sdk/CHANGELOG.md:**
- v0.2.0: `foundry-sdk-v0.1.0` tag doesn't exist — linked to release tag (initial release)

All replacement tags verified via `git tag -l`.