### PR TITLE
fix(streams): use empty separator in finalText() for text block concatenation

### DIFF
--- a/src/lib/BetaMessageStream.ts
+++ b/src/lib/BetaMessageStream.ts
@@ -347,7 +347,7 @@ export class BetaMessageStream<ParsedT = null> implements AsyncIterable<BetaMess
     if (textBlocks.length === 0) {
       throw new AnthropicError('stream ended without producing a content block with type=text');
     }
-    return textBlocks.join(' ');
+    return textBlocks.join('');
   }
 
   /**

--- a/src/lib/MessageStream.ts
+++ b/src/lib/MessageStream.ts
@@ -355,7 +355,7 @@ export class MessageStream<ParsedT = null> implements AsyncIterable<MessageStrea
     if (textBlocks.length === 0) {
       throw new AnthropicError('stream ended without producing a content block with type=text');
     }
-    return textBlocks.join(' ');
+    return textBlocks.join('');
   }
 
   /**

--- a/tests/api-resources/MessageStream.test.ts
+++ b/tests/api-resources/MessageStream.test.ts
@@ -226,6 +226,54 @@ describe('MessageStream class', () => {
     expect(finalText).toBe("I'll check the current weather in Paris for you.");
   });
 
+  it('concatenates multiple text blocks without extra spaces in finalText', async () => {
+    const { fetch, handleStreamEvents } = mockFetch();
+
+    const anthropic = new Anthropic({ apiKey: '...', fetch });
+
+    handleStreamEvents([
+      {
+        type: 'message_start',
+        message: {
+          id: 'msg_multi_text',
+          type: 'message',
+          role: 'assistant',
+          content: [],
+          model: 'claude-opus-4-20250514',
+          stop_reason: null,
+          stop_sequence: null,
+          usage: { input_tokens: 10, output_tokens: 0 },
+        },
+      },
+      { type: 'content_block_start', index: 0, content_block: { type: 'text', text: '' } },
+      { type: 'content_block_delta', index: 0, delta: { type: 'text_delta', text: 'Hello' } },
+      { type: 'content_block_delta', index: 0, delta: { type: 'text_delta', text: ' world' } },
+      { type: 'content_block_stop', index: 0 },
+      { type: 'content_block_start', index: 1, content_block: { type: 'text', text: '' } },
+      { type: 'content_block_delta', index: 1, delta: { type: 'text_delta', text: ', how' } },
+      { type: 'content_block_delta', index: 1, delta: { type: 'text_delta', text: ' are you?' } },
+      { type: 'content_block_stop', index: 1 },
+      {
+        type: 'message_delta',
+        delta: { stop_reason: 'end_turn', stop_sequence: null },
+        usage: { output_tokens: 8 },
+      },
+      { type: 'message_stop' },
+    ]);
+
+    const stream = anthropic.messages.stream({
+      max_tokens: 1024,
+      model: 'claude-opus-4-20250514',
+      messages: [{ role: 'user', content: 'Say something' }],
+    });
+
+    for await (const _event of stream) {
+    }
+
+    const finalText = await stream.finalText();
+    expect(finalText).toBe('Hello world, how are you?');
+  });
+
   it('does not throw unhandled rejection with withResponse()', async () => {
     const { fetch, handleRequest } = mockFetch();
     const anthropic = new Anthropic({


### PR DESCRIPTION
## Problem

`MessageStream#finalText()` and `BetaMessageStream#finalText()` use `join(' ')` to combine multiple text blocks, inserting an unexpected space character between adjacent blocks. This causes double spaces when the model returns text blocks with trailing/leading whitespace (e.g. `"Hello " + " world"` becomes `"Hello   world"`).

## Fix

Changed to `join('')` in both `MessageStream` and `BetaMessageStream`, which matches the JSDoc ("concatenated together if there are more than one text blocks") and the Python SDK (`"".join(text_blocks)`).

Added a test that streams two text blocks and verifies `finalText()` concatenates them without inserting extra whitespace.