### PR TITLE
fix: implement ApiKeySetter — async apiKey functions were silently discarded

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -350,6 +350,7 @@ export const AI_PROMPT = '\\n\\nAssistant:';
  */
 export class BaseAnthropic {
   apiKey: string | null;
+  #apiKeySetter: ApiKeySetter | null;
   authToken: string | null;
 
   baseURL: string;
@@ -415,6 +416,7 @@ export class BaseAnthropic {
     this._options = options;
 
     this.apiKey = typeof apiKey === 'string' ? apiKey : null;
+    this.#apiKeySetter = typeof apiKey === 'function' ? apiKey : null;
     this.authToken = authToken;
   }
 
@@ -431,7 +433,7 @@ export class BaseAnthropic {
       logLevel: this.logLevel,
       fetch: this.fetch,
       fetchOptions: this.fetchOptions,
-      apiKey: this.apiKey,
+      apiKey: this.#apiKeySetter ?? this.apiKey,
       authToken: this.authToken,
       ...options,
     });
@@ -454,14 +456,14 @@ export class BaseAnthropic {
       return;
     }
 
-    if (this.apiKey && values.get('x-api-key')) {
+    if ((this.apiKey || this.#apiKeySetter) && !nulls.has('x-api-key')) {
       return;
     }
     if (nulls.has('x-api-key')) {
       return;
     }
 
-    if (this.authToken && values.get('authorization')) {
+    if (this.authToken && !nulls.has('authorization')) {
       return;
     }
     if (nulls.has('authorization')) {
@@ -478,6 +480,22 @@ export class BaseAnthropic {
   }
 
   protected async apiKeyAuth(opts: FinalRequestOptions): Promise<NullableHeaders | undefined> {
+    if (this.#apiKeySetter != null) {
+      let key: string;
+      try {
+        key = await this.#apiKeySetter();
+      } catch (err) {
+        throw new Errors.AnthropicError('Failed to obtain API key from apiKey function', {
+          cause: err,
+        });
+      }
+      if (!key || typeof key !== 'string') {
+        throw new Errors.AnthropicError(
+          'The apiKey function must return a non-empty string',
+        );
+      }
+      return buildHeaders([{ 'X-Api-Key': key }]);
+    }
     if (this.apiKey == null) {
       return undefined;
     }


### PR DESCRIPTION
## Summary

`ApiKeySetter` (async function for dynamic API key rotation) is documented in `ClientOptions.apiKey` JSDoc but was never implemented. The constructor silently discards function values, causing all requests to be sent without authentication.

## Problem

```typescript
// ClientOptions accepts functions (line 263):
apiKey?: string | ApiKeySetter | null | undefined;

// JSDoc says (lines 255-261):
// "When a function is provided, it is invoked before each request
//  so you can rotate or refresh credentials at runtime."

// But constructor only stores strings (line 417):
this.apiKey = typeof apiKey === 'string' ? apiKey : null;
// Functions are silently discarded → apiKey = null → no auth header
```

**Before fix:**
```typescript
const client = new Anthropic({
  apiKey: async () => vault.getSecret('anthropic-key'),
});
// All requests sent WITHOUT X-Api-Key header → 401 errors
// No error thrown — silent failure
```

**After fix:**
```typescript
const client = new Anthropic({
  apiKey: async () => vault.getSecret('anthropic-key'),
});
// Function called before each request
// X-Api-Key header set with the returned value
```

## Changes

- Store `ApiKeySetter` functions in a private `#apiKeySetter` field
- Invoke the setter in `apiKeyAuth()` before each request
- Wrap setter errors in `AnthropicError` with the original as `cause`
- Reject empty strings returned by the setter
- Preserve the setter through `withOptions()`
- Update `validateHeaders` to recognize setter-based auth as valid

## Test plan

- [x] Async function key: `X-Api-Key` header populated with returned value
- [x] Static string key: unchanged behavior
- [x] `withOptions()`: setter preserved across client copies
- [x] Function throws: wrapped in `AnthropicError` with original as `cause`
- [x] Function returns empty string: throws with descriptive message
- [x] Full test suite: no new failures (66 pre-existing failures unchanged)