### PR TITLE
fix: prevent stack overflow in toBase64 for large inputs

### DIFF
--- a/src/internal/utils/base64.ts
+++ b/src/internal/utils/base64.ts
@@ -15,7 +15,14 @@ export const toBase64 = (data: string | Uint8Array | null | undefined): string =
   }
 
   if (typeof btoa !== 'undefined') {
-    return btoa(String.fromCharCode.apply(null, data as any));
+    // Process in chunks to avoid stack overflow with large inputs.
+    // String.fromCharCode.apply has a max argument count (~65536).
+    let binary = '';
+    const chunkSize = 8192;
+    for (let i = 0; i < data.length; i += chunkSize) {
+      binary += String.fromCharCode(...data.subarray(i, Math.min(i + chunkSize, data.length)));
+    }
+    return btoa(binary);
   }
 
   throw new AnthropicError('Cannot generate base64 string; Expected `Buffer` or `btoa` to be defined');

--- a/tests/base64.test.ts
+++ b/tests/base64.test.ts
@@ -50,6 +50,24 @@ describe.each(['Buffer', 'atob'])('with %s', (mode) => {
     });
   });
 
+  test('toBase64 handles large input without stack overflow', () => {
+    // 200KB of data - would cause "Maximum call stack size exceeded"
+    // with the old String.fromCharCode.apply/spread approach
+    const size = 200 * 1024;
+    const largeData = new Uint8Array(size);
+    for (let i = 0; i < size; i++) {
+      largeData[i] = i % 256;
+    }
+
+    const encoded = toBase64(largeData);
+    expect(typeof encoded).toBe('string');
+    expect(encoded.length).toBeGreaterThan(0);
+
+    // Round-trip: decode and verify it matches
+    const decoded = fromBase64(encoded);
+    expect(decoded).toEqual(largeData);
+  });
+
   test('fromBase64', () => {
     const testCases = [
       {


### PR DESCRIPTION
## Summary
- `toBase64` uses `String.fromCharCode.apply(null, data)` in the `btoa` path, which passes the entire `Uint8Array` as individual arguments. JavaScript engines have a maximum argument count (~65,536), so inputs larger than ~100KB cause `RangeError: Maximum call stack size exceeded`.
- Fix: process bytes in 8,192-byte chunks via `String.fromCharCode(...data.subarray(i, i + chunkSize))`, keeping each call well under the limit.
- Added a test that round-trips a 200KB `Uint8Array` through `toBase64`/`fromBase64` in both `Buffer` and `btoa` modes.

Fixes #932

## Test plan
- [x] Existing `toBase64` and `fromBase64` tests pass (both Buffer and atob modes)
- [x] New 200KB round-trip test passes in both modes
- [ ] CI green