### PR TITLE
fix(tools): forward request options headers in BetaToolRunner compaction calls

### DIFF
--- a/src/lib/tools/BetaToolRunner.ts
+++ b/src/lib/tools/BetaToolRunner.ts
@@ -144,7 +144,8 @@ export class BetaToolRunner<Stream extends boolean> {
         max_tokens: this.#state.params.max_tokens,
       },
       {
-        headers: { 'x-stainless-helper': 'compaction' },
+        ...this.#options,
+        headers: buildHeaders([{ 'x-stainless-helper': 'compaction' }, this.#options?.headers]),
       },
     );
 

--- a/tests/lib/tools/ToolRunner.test.ts
+++ b/tests/lib/tools/ToolRunner.test.ts
@@ -1141,4 +1141,150 @@ describe('ToolRunner', () => {
       expect(capturedHelperHeader).toContain('mcpContent');
     });
   });
+
+  describe('request options headers', () => {
+    it('forwards custom headers on every API call across tool-use turns', async () => {
+      const { fetch, handleRequest } = mockFetch();
+      const client = new Anthropic({ apiKey: 'test-key', fetch, maxRetries: 0 });
+
+      const capturedHeaders: (string | null)[] = [];
+
+      // First call: assistant requests a tool
+      handleRequest(async (_req, init) => {
+        const headers = init?.headers;
+        if (headers instanceof Headers) {
+          capturedHeaders.push(headers.get('x-custom-header'));
+        }
+        return new Response(
+          JSON.stringify({
+            id: 'msg_1',
+            type: 'message',
+            role: 'assistant',
+            content: [{ type: 'tool_use', id: 'tool_1', name: 'getWeather', input: { location: 'SF' } }],
+            model: 'claude-3-5-sonnet-latest',
+            stop_reason: 'tool_use',
+            stop_sequence: null,
+            container: null,
+            context_management: null,
+            usage: { input_tokens: 10, output_tokens: 5 },
+          }),
+          { headers: { 'content-type': 'application/json' } },
+        );
+      });
+
+      // Second call: assistant gives final response after tool result
+      handleRequest(async (_req, init) => {
+        const headers = init?.headers;
+        if (headers instanceof Headers) {
+          capturedHeaders.push(headers.get('x-custom-header'));
+        }
+        return new Response(
+          JSON.stringify({
+            id: 'msg_2',
+            type: 'message',
+            role: 'assistant',
+            content: [{ type: 'text', text: 'The weather is sunny', citations: null }],
+            model: 'claude-3-5-sonnet-latest',
+            stop_reason: 'end_turn',
+            stop_sequence: null,
+            container: null,
+            context_management: null,
+            usage: { input_tokens: 20, output_tokens: 10 },
+          }),
+          { headers: { 'content-type': 'application/json' } },
+        );
+      });
+
+      const runner = client.beta.messages.toolRunner(
+        {
+          model: 'claude-3-5-sonnet-latest',
+          max_tokens: 1000,
+          messages: [{ role: 'user', content: 'What is the weather?' }],
+          tools: [weatherTool],
+        },
+        {
+          headers: { 'x-custom-header': 'my-custom-value' },
+        },
+      );
+
+      await runner.runUntilDone();
+
+      // Both API calls should have received the custom header
+      expect(capturedHeaders).toHaveLength(2);
+      expect(capturedHeaders[0]).toBe('my-custom-value');
+      expect(capturedHeaders[1]).toBe('my-custom-value');
+    });
+
+    it('forwards defaultHeaders on every API call across tool-use turns', async () => {
+      const { fetch, handleRequest } = mockFetch();
+      const client = new Anthropic({
+        apiKey: 'test-key',
+        fetch,
+        maxRetries: 0,
+        defaultHeaders: { 'x-default-header': 'default-value' },
+      });
+
+      const capturedHeaders: (string | null)[] = [];
+
+      // First call: assistant requests a tool
+      handleRequest(async (_req, init) => {
+        const headers = init?.headers;
+        if (headers instanceof Headers) {
+          capturedHeaders.push(headers.get('x-default-header'));
+        }
+        return new Response(
+          JSON.stringify({
+            id: 'msg_1',
+            type: 'message',
+            role: 'assistant',
+            content: [{ type: 'tool_use', id: 'tool_1', name: 'getWeather', input: { location: 'NYC' } }],
+            model: 'claude-3-5-sonnet-latest',
+            stop_reason: 'tool_use',
+            stop_sequence: null,
+            container: null,
+            context_management: null,
+            usage: { input_tokens: 10, output_tokens: 5 },
+          }),
+          { headers: { 'content-type': 'application/json' } },
+        );
+      });
+
+      // Second call: assistant gives final response
+      handleRequest(async (_req, init) => {
+        const headers = init?.headers;
+        if (headers instanceof Headers) {
+          capturedHeaders.push(headers.get('x-default-header'));
+        }
+        return new Response(
+          JSON.stringify({
+            id: 'msg_2',
+            type: 'message',
+            role: 'assistant',
+            content: [{ type: 'text', text: 'It is sunny in NYC', citations: null }],
+            model: 'claude-3-5-sonnet-latest',
+            stop_reason: 'end_turn',
+            stop_sequence: null,
+            container: null,
+            context_management: null,
+            usage: { input_tokens: 20, output_tokens: 10 },
+          }),
+          { headers: { 'content-type': 'application/json' } },
+        );
+      });
+
+      const runner = client.beta.messages.toolRunner({
+        model: 'claude-3-5-sonnet-latest',
+        max_tokens: 1000,
+        messages: [{ role: 'user', content: 'What is the weather in NYC?' }],
+        tools: [weatherTool],
+      });
+
+      await runner.runUntilDone();
+
+      // Both API calls should have the default header from the client
+      expect(capturedHeaders).toHaveLength(2);
+      expect(capturedHeaders[0]).toBe('default-value');
+      expect(capturedHeaders[1]).toBe('default-value');
+    });
+  });
 });


### PR DESCRIPTION
## Summary

- Fixed `BetaToolRunner.#checkAndCompact()` dropping user-provided request options headers when making the compaction API call
- The compaction call was only passing `{ headers: { 'x-stainless-helper': 'compaction' } }`, discarding any headers from `this.#options` that were provided via `toolRunner(params, options)`
- Now merges stored request options with the compaction header using `buildHeaders()`, consistent with how the main loop calls on lines 195/202 already pass `this.#options`

## What changed

**`src/lib/tools/BetaToolRunner.ts`** (1 line change):
```diff
-        headers: { 'x-stainless-helper': 'compaction' },
+        ...this.#options,
+        headers: buildHeaders([{ 'x-stainless-helper': 'compaction' }, this.#options?.headers]),
```

**`tests/lib/tools/ToolRunner.test.ts`** (2 new tests):
- `forwards custom headers on every API call across tool-use turns` — verifies request-level headers from `toolRunner(params, { headers })` persist on follow-up calls
- `forwards defaultHeaders on every API call across tool-use turns` — verifies client-level `defaultHeaders` persist across the tool-use loop

## Test plan

- [x] Both new tests pass
- [x] All 128 existing lib tests pass (`npx jest tests/lib/`)
- [x] TypeScript compiles cleanly (`npx tsc -p tsconfig.json --noEmit`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)