### PR TITLE
fix: prevent stack overflow in toBase64 for large inputs in non-Node environments

### DIFF
--- a/src/internal/utils/base64.ts
+++ b/src/internal/utils/base64.ts
@@ -15,7 +15,17 @@ export const toBase64 = (data: string | Uint8Array | null | undefined): string =
   }
 
   if (typeof btoa !== 'undefined') {
-    return btoa(String.fromCharCode.apply(null, data as any));
+    // Process in chunks to avoid stack overflow with large inputs.
+    // String.fromCharCode.apply() passes all bytes as arguments,
+    // which exceeds the JS engine's max argument limit (~65536) for
+    // inputs larger than ~100KB (e.g. image uploads).
+    const CHUNK_SIZE = 0x8000; // 32KB chunks
+    const parts: string[] = [];
+    for (let i = 0; i < data.length; i += CHUNK_SIZE) {
+      const chunk = data.subarray(i, i + CHUNK_SIZE);
+      parts.push(String.fromCharCode.apply(null, chunk as any));
+    }
+    return btoa(parts.join(''));
   }
 
   throw new AnthropicError('Cannot generate base64 string; Expected `Buffer` or `btoa` to be defined');


### PR DESCRIPTION
## Problem

`toBase64` in `src/internal/utils/base64.ts` crashes with `RangeError: Maximum call stack size exceeded` when encoding inputs larger than ~100KB in non-Node environments (browsers, Cloudflare Workers, Deno, etc.).

**Reproduction:**
```js
const large = new Uint8Array(200 * 1024); // 200KB
toBase64(large); // RangeError: Maximum call stack size exceeded
```

This affects any use case that sends large payloads through the SDK in browser environments, most commonly **image uploads** via base64 encoding.

## Root Cause

Line 18 uses `String.fromCharCode.apply(null, data)`, which spreads the entire `Uint8Array` as individual function arguments. JavaScript engines have a maximum argument limit (typically ~65,536), so any input larger than ~64KB overflows the call stack.

Node.js environments are unaffected because they hit the `Buffer.from()` path on line 10, which has no such limitation.

## Solution

Process the `Uint8Array` in 32KB chunks (0x8000 bytes), convert each chunk separately with `String.fromCharCode.apply()`, then join before passing to `btoa()`. This stays well within the argument limit while producing identical output.

```typescript
const CHUNK_SIZE = 0x8000;
const parts: string[] = [];
for (let i = 0; i < data.length; i += CHUNK_SIZE) {
  const chunk = data.subarray(i, i + CHUNK_SIZE);
  parts.push(String.fromCharCode.apply(null, chunk as any));
}
return btoa(parts.join(''));
```

This is a well-established pattern used by libraries like `js-base64`, Firebase SDK, and others that need to encode large binary data in browser environments.

## Note on Generated Code

This file is marked as generated by Stainless. The fix should ideally be upstreamed to the code generator to persist across regenerations. In the meantime, this patch fixes the bug for current users.

## Test Plan

- `toBase64(new Uint8Array(0))` → empty string ✅
- `toBase64(new Uint8Array(100))` → valid base64 (small input, existing behavior) ✅
- `toBase64(new Uint8Array(200 * 1024))` → valid base64 without stack overflow ✅
- `toBase64("hello")` → string path unaffected ✅
- Node.js environment → uses Buffer path, unaffected ✅

Closes #932