### PR TITLE
fix: recover when TextDecoder rejects Uint8Array views

### DIFF
--- a/src/internal/utils/bytes.ts
+++ b/src/internal/utils/bytes.ts
@@ -22,11 +22,17 @@ export function encodeUTF8(str: string) {
   )(str);
 }
 
-let decodeUTF8_: (bytes: Uint8Array) => string;
+let decodeUTF8Decoder_: { decode: (input?: ArrayBuffer | ArrayBufferView | null) => string };
 export function decodeUTF8(bytes: Uint8Array) {
-  let decoder;
-  return (
-    decodeUTF8_ ??
-    ((decoder = new (globalThis as any).TextDecoder()), (decodeUTF8_ = decoder.decode.bind(decoder)))
-  )(bytes);
+  const decoder = decodeUTF8Decoder_ ?? (decodeUTF8Decoder_ = new (globalThis as any).TextDecoder());
+
+  try {
+    return decoder.decode(bytes);
+  } catch (error) {
+    if (!(error instanceof TypeError)) {
+      throw error;
+    }
+
+    return decoder.decode(bytes.slice().buffer);
+  }
 }

--- a/tests/api-resources/MessageStream.test.ts
+++ b/tests/api-resources/MessageStream.test.ts
@@ -198,6 +198,78 @@ describe('MessageStream class', () => {
     expect(finalText).toBe('Hello there!');
   });
 
+  it('handles strict TextDecoder behavior on messages.stream()', async () => {
+    const OriginalTextDecoder = globalThis.TextDecoder;
+    const nativeDecoder = new OriginalTextDecoder();
+
+    class ArrayBufferOnlyTextDecoder {
+      readonly encoding = 'utf-8';
+      readonly fatal = false;
+      readonly ignoreBOM = false;
+
+      constructor(label?: string, options?: TextDecoderOptions) {
+        void label;
+        void options;
+      }
+
+      decode(input?: ArrayBuffer | ArrayBufferView | null) {
+        if (input == null) {
+          return nativeDecoder.decode();
+        }
+
+        if (!(input instanceof ArrayBuffer)) {
+          throw new TypeError(
+            "Failed to execute 'decode' on 'TextDecoder': parameter 1 is not of type 'ArrayBuffer'",
+          );
+        }
+
+        return nativeDecoder.decode(input);
+      }
+    }
+
+    Object.defineProperty(globalThis, 'TextDecoder', {
+      configurable: true,
+      writable: true,
+      value: ArrayBufferOnlyTextDecoder as unknown as typeof TextDecoder,
+    });
+    jest.resetModules();
+
+    try {
+      const { default: ReloadedAnthropic } = await import('@anthropic-ai/sdk');
+      const { fetch, handleStreamEvents } = mockFetch();
+      const anthropic = new ReloadedAnthropic({ apiKey: '...', fetch });
+
+      const fixtureContent = loadFixture('basic_response.txt');
+      const streamEvents = await parseSSEFixture(fixtureContent);
+      handleStreamEvents(streamEvents);
+
+      const stream = anthropic.messages.stream({
+        max_tokens: 1024,
+        model: 'claude-opus-4-20250514',
+        messages: [{ role: 'user', content: 'Say hello there!' }],
+      });
+
+      const events: MessageStreamEvent[] = [];
+      for await (const event of stream) {
+        events.push(event);
+      }
+
+      await stream.done();
+      const finalMessage = await stream.finalMessage();
+      const finalText = await stream.finalText();
+
+      assertBasicResponse(events, finalMessage);
+      expect(finalText).toBe('Hello there!');
+    } finally {
+      Object.defineProperty(globalThis, 'TextDecoder', {
+        configurable: true,
+        writable: true,
+        value: OriginalTextDecoder,
+      });
+      jest.resetModules();
+    }
+  });
+
   it('handles tool use response fixture', async () => {
     const { fetch, handleStreamEvents } = mockFetch();
 

--- a/tests/internal/utils/bytes.test.ts
+++ b/tests/internal/utils/bytes.test.ts
@@ -1,0 +1,48 @@
+describe('decodeUTF8', () => {
+  const OriginalTextDecoder = globalThis.TextDecoder;
+
+  afterEach(() => {
+    Object.defineProperty(globalThis, 'TextDecoder', {
+      configurable: true,
+      writable: true,
+      value: OriginalTextDecoder,
+    });
+    jest.resetModules();
+  });
+
+  test('falls back to ArrayBuffer when TextDecoder rejects Uint8Array views', async () => {
+    const nativeDecoder = new OriginalTextDecoder();
+
+    class ArrayBufferOnlyTextDecoder {
+      readonly encoding = 'utf-8';
+      readonly fatal = false;
+      readonly ignoreBOM = false;
+
+      decode(input?: ArrayBuffer | ArrayBufferView | null) {
+        if (input == null) {
+          return nativeDecoder.decode();
+        }
+
+        if (!(input instanceof ArrayBuffer)) {
+          throw new TypeError(
+            "Failed to execute 'decode' on 'TextDecoder': parameter 1 is not of type 'ArrayBuffer'",
+          );
+        }
+
+        return nativeDecoder.decode(input);
+      }
+    }
+
+    Object.defineProperty(globalThis, 'TextDecoder', {
+      configurable: true,
+      writable: true,
+      value: ArrayBufferOnlyTextDecoder as unknown as typeof TextDecoder,
+    });
+    jest.resetModules();
+
+    const { decodeUTF8 } = await import('@anthropic-ai/sdk/internal/utils/bytes');
+    const bytes = new Uint8Array([0x78, 0x66, 0x6f, 0x6f, 0x79]).subarray(1, 4);
+
+    expect(decodeUTF8(bytes)).toBe('foo');
+  });
+});


### PR DESCRIPTION
Fixes #883

## Summary

This hardens the SDK stream decoding path for environments where `TextDecoder.decode()` rejects `Uint8Array` views or subarrays and only accepts a plain `ArrayBuffer`.

The runtime change keeps the normal path the same, but retries with `bytes.slice().buffer` when `decodeUTF8()` hits that `TypeError`.

## Why

On AWS Lambda `nodejs22.x`, users reported stream decoding failures with:

`Failed to execute 'decode' on 'TextDecoder': parameter 1 is not of type 'ArrayBuffer'`

I reproduced the SDK-level failure mode around the public streaming helper path and verified that the fallback recovers cleanly.

## What changed

- keep the `TextDecoder` instance instead of caching a bound `decode` function
- try `decoder.decode(bytes)` first
- on `TypeError`, retry with `decoder.decode(bytes.slice().buffer)`
- add a focused regression test for `decodeUTF8()`
- add a higher-level regression test for `messages.stream()` under stricter `TextDecoder` behavior

## Validation

- `./node_modules/.bin/jest tests/internal/utils/bytes.test.ts tests/api-resources/MessageStream.test.ts --runInBand`
- real AWS Lambda `nodejs22.x` repro using the public `messages.stream()` path
  - before fix: probe failed with the `ArrayBuffer` error
  - after fix: same probe completed and returned the final streamed message

## Notes

I could not make a minimal direct `TextDecoder.decode(Uint8Array view)` probe fail natively on the exact Lambda runtime I tested in isolation, so I don't want to overclaim there.

But the SDK-level failure mode is reproducible under stricter decoder behavior, and this fallback fixes that path while preserving the normal case.
