### PR TITLE
fix: preserve directory paths in multipart upload filenames

### DIFF
--- a/src/resources/beta/skills/versions.ts
+++ b/src/resources/beta/skills/versions.ts
@@ -39,6 +39,7 @@ export class Versions extends APIResource {
           ]),
         },
         this._client,
+        false,
       ),
     );
   }


### PR DESCRIPTION
## Summary

Fixes #968

The `versions.create()` method was missing the `stripFilenames: false` parameter when calling `multipartFormRequestOptions`, causing the `getName` function to strip directory paths from filenames (e.g., `my-skill/SKILL.md` became `SKILL.md`). This broke `skills.versions.create()` which requires the directory structure to be preserved.

## Fix

Added `false` as the third argument (`stripFilenames`) to the `multipartFormRequestOptions` call in `versions.create()`, matching the existing pattern in `skills.create()` which already correctly passes `stripFilenames: false`.

This is a targeted, one-line fix — it does not change the default behavior for other endpoints (like the files API) where path stripping is appropriate for browser security reasons.

## Test

```typescript
// Before: fails with 400 'SKILL.md file must be exactly in the top-level folder'
await client.beta.skills.versions.create(skillId, {
  files: [new File(['content'], 'my-skill/SKILL.md')]
});

// After: works correctly, directory path preserved
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)