### PR TITLE
fix(partial-json): merge consecutive string tokens in generate

### DIFF
--- a/src/_vendor/partial-json-parser/parser.ts
+++ b/src/_vendor/partial-json-parser/parser.ts
@@ -245,16 +245,22 @@ const tokenize = (input: string): Token[] => {
   },
   generate = (tokens: Token[]): string => {
     let output = '';
+    let prevType: string | null = null;
 
     tokens.map((token) => {
       switch (token.type) {
         case 'string':
-          output += '"' + token.value + '"';
+          if (prevType === 'string') {
+            output = output.slice(0, -1) + '\\"' + token.value + '"';
+          } else {
+            output += '"' + token.value + '"';
+          }
           break;
         default:
           output += token.value;
           break;
       }
+      prevType = token.type;
     });
 
     return output;


### PR DESCRIPTION
## Summary

- When the partial JSON tokenizer produces consecutive `string` tokens (e.g., from strings containing escaped quotes that get split across token boundaries), the `generate` function now merges them with an escaped quote instead of producing invalid JSON with adjacent quoted strings like `"hello""world"`.

## Test plan

- [ ] Verify `partialParse('{"key": "hello"}')` still works correctly
- [ ] Verify partial JSON with escaped quotes handles consecutive string tokens

🤖 Generated with [Claude Code](https://claude.com/claude-code)