### PR TITLE
feat(api): add missing beta strings, task_budget, and cache scope

### DIFF
--- a/src/resources/beta/beta.ts
+++ b/src/resources/beta/beta.ts
@@ -268,7 +268,11 @@ export type AnthropicBeta =
   | 'model-context-window-exceeded-2025-08-26'
   | 'skills-2025-10-02'
   | 'fast-mode-2026-02-01'
-  | 'output-300k-2026-03-24';
+  | 'output-300k-2026-03-24'
+  | 'prompt-caching-scope-2026-01-05'
+  | 'redact-thinking-2026-02-12'
+  | 'token-efficient-tools-2026-03-28'
+  | 'task-budgets-2026-03-13';
 
 export interface BetaAPIError {
   message: string;

--- a/src/resources/beta/index.ts
+++ b/src/resources/beta/index.ts
@@ -120,6 +120,7 @@ export {
   type BetaMessageTokensCount,
   type BetaMetadata,
   type BetaOutputConfig,
+  type BetaOutputConfigTaskBudget,
   type BetaPlainTextSource,
   type BetaRawContentBlockDelta,
   type BetaRawContentBlockDeltaEvent,

--- a/src/resources/beta/messages/index.ts
+++ b/src/resources/beta/messages/index.ts
@@ -111,6 +111,7 @@ export {
   type BetaMessageTokensCount,
   type BetaMetadata,
   type BetaOutputConfig,
+  type BetaOutputConfigTaskBudget,
   type BetaPlainTextSource,
   type BetaRawContentBlockDelta,
   type BetaRawContentBlockDeltaEvent,

--- a/src/resources/beta/messages/messages.ts
+++ b/src/resources/beta/messages/messages.ts
@@ -64,6 +64,30 @@ const DEPRECATED_MODELS: {
 
 const MODELS_TO_WARN_WITH_THINKING_ENABLED: Model[] = ['claude-opus-4-6'];
 
+/**
+ * Returns true if any cache_control block in the request has scope: 'global'.
+ * Used to auto-inject the prompt-caching-scope-2026-01-05 beta header.
+ */
+function hasGlobalCacheScope(body: Omit<MessageCreateParams, 'betas'>): boolean {
+  const isGlobal = (cc: unknown): boolean =>
+    cc != null && typeof cc === 'object' && (cc as Record<string, unknown>)['scope'] === 'global';
+
+  if (Array.isArray(body.system)) {
+    if (body.system.some((b: any) => isGlobal(b.cache_control))) return true;
+  }
+  if (Array.isArray(body.tools)) {
+    if (body.tools.some((t: any) => isGlobal(t.cache_control))) return true;
+  }
+  for (const message of body.messages ?? []) {
+    const content = message.content;
+    if (Array.isArray(content)) {
+      if (content.some((b: any) => isGlobal(b.cache_control))) return true;
+    }
+  }
+  return false;
+}
+
+
 export class Messages extends APIResource {
   batches: BatchesAPI.Batches = new BatchesAPI.Batches(this._client);
 
@@ -104,6 +128,19 @@ export class Messages extends APIResource {
 
     const { betas, ...body } = modifiedParams;
 
+    // Auto-inject required beta headers based on request params so callers
+    // don't have to track which betas go with which fields.
+    const activeBetas: string[] = betas ? [...betas] : [];
+    if ((this._client as any).authToken && !activeBetas.includes('oauth-2025-04-20')) {
+      activeBetas.push('oauth-2025-04-20');
+    }
+    if (body.output_config?.task_budget && !activeBetas.includes('task-budgets-2026-03-13')) {
+      activeBetas.push('task-budgets-2026-03-13');
+    }
+    if (hasGlobalCacheScope(body) && !activeBetas.includes('prompt-caching-scope-2026-01-05')) {
+      activeBetas.push('prompt-caching-scope-2026-01-05');
+    }
+
     if (body.model in DEPRECATED_MODELS) {
       console.warn(
         `The model '${body.model}' is deprecated and will reach end-of-life on ${
@@ -136,7 +173,7 @@ export class Messages extends APIResource {
       timeout: timeout ?? 600000,
       ...options,
       headers: buildHeaders([
-        { ...(betas?.toString() != null ? { 'anthropic-beta': betas?.toString() } : undefined) },
+        { ...(activeBetas.length > 0 ? { 'anthropic-beta': activeBetas.toString() } : undefined) },
         helperHeader,
         options?.headers,
       ]),
@@ -379,6 +416,13 @@ export interface BetaCacheControlEphemeral {
    * Defaults to `5m`.
    */
   ttl?: '5m' | '1h';
+
+  /**
+   * Cache scope. When set to `'global'`, the cache entry is shared across all API
+   * requests using the same content, regardless of session. Requires the
+   * `prompt-caching-scope-2026-01-05` beta header.
+   */
+  scope?: 'global';
 }
 
 export interface BetaCacheCreation {
@@ -1658,6 +1702,29 @@ export interface BetaOutputConfig {
    * [structured outputs](https://platform.claude.com/docs/en/build-with-claude/structured-outputs)
    */
   format?: BetaJSONOutputFormat | null;
+
+  /**
+   * Token budget for this task. When provided with the `task-budgets-2026-03-13`
+   * beta, Claude will stop generating output once the remaining budget reaches zero.
+   */
+  task_budget?: BetaOutputConfigTaskBudget | null;
+}
+
+export interface BetaOutputConfigTaskBudget {
+  /**
+   * The type of budget unit.
+   */
+  type: 'tokens';
+
+  /**
+   * Total token budget allocated for this task.
+   */
+  total: number;
+
+  /**
+   * Remaining token budget. Claude will stop generating once this reaches zero.
+   */
+  remaining: number;
 }
 
 export interface BetaPlainTextSource {
@@ -4234,6 +4301,7 @@ export declare namespace Messages {
     type BetaMessageTokensCount as BetaMessageTokensCount,
     type BetaMetadata as BetaMetadata,
     type BetaOutputConfig as BetaOutputConfig,
+    type BetaOutputConfigTaskBudget as BetaOutputConfigTaskBudget,
     type BetaPlainTextSource as BetaPlainTextSource,
     type BetaRawContentBlockDelta as BetaRawContentBlockDelta,
     type BetaRawContentBlockDeltaEvent as BetaRawContentBlockDeltaEvent,

--- a/src/resources/beta/messages/messages.ts
+++ b/src/resources/beta/messages/messages.ts
@@ -73,20 +73,19 @@ function hasGlobalCacheScope(body: Omit<MessageCreateParams, 'betas'>): boolean 
     cc != null && typeof cc === 'object' && (cc as Record<string, unknown>)['scope'] === 'global';
 
   if (Array.isArray(body.system)) {
-    if (body.system.some((b: any) => isGlobal(b.cache_control))) return true;
+    if (body.system.some((b) => isGlobal((b as { cache_control?: unknown }).cache_control))) return true;
   }
   if (Array.isArray(body.tools)) {
-    if (body.tools.some((t: any) => isGlobal(t.cache_control))) return true;
+    if (body.tools.some((t) => isGlobal((t as { cache_control?: unknown }).cache_control))) return true;
   }
   for (const message of body.messages ?? []) {
     const content = message.content;
     if (Array.isArray(content)) {
-      if (content.some((b: any) => isGlobal(b.cache_control))) return true;
+      if (content.some((b) => isGlobal((b as { cache_control?: unknown }).cache_control))) return true;
     }
   }
   return false;
 }
-
 
 export class Messages extends APIResource {
   batches: BatchesAPI.Batches = new BatchesAPI.Batches(this._client);
@@ -131,6 +130,7 @@ export class Messages extends APIResource {
     // Auto-inject required beta headers based on request params so callers
     // don't have to track which betas go with which fields.
     const activeBetas: string[] = betas ? [...betas] : [];
+    // authToken lives on the concrete Anthropic class, not BaseAnthropic; cast is unavoidable.
     if ((this._client as any).authToken && !activeBetas.includes('oauth-2025-04-20')) {
       activeBetas.push('oauth-2025-04-20');
     }
@@ -201,15 +201,15 @@ export class Messages extends APIResource {
     params: Params,
     options?: RequestOptions,
   ): APIPromise<ParsedBetaMessage<ExtractParsedContentFromBetaParams<Params>>> {
-    options = {
-      ...options,
-      headers: buildHeaders([
-        { 'anthropic-beta': [...(params.betas ?? []), 'structured-outputs-2025-12-15'].toString() },
-        options?.headers,
-      ]),
-    };
+    // Route structured-outputs beta through params.betas so create()'s activeBetas
+    // logic handles all header construction in one place. Avoids options.headers
+    // arriving after activeBetas in buildHeaders and clobbering auto-injected betas.
+    const paramsWithBeta = {
+      ...params,
+      betas: [...(params.betas ?? []), 'structured-outputs-2025-12-15'],
+    } as Params;
 
-    return this.create(params, options).then((message) =>
+    return this.create(paramsWithBeta, options).then((message) =>
       parseBetaMessage(message, params, { logger: this._client.logger ?? console }),
     ) as APIPromise<ParsedBetaMessage<ExtractParsedContentFromBetaParams<Params>>>;
   }
@@ -1724,7 +1724,7 @@ export interface BetaOutputConfigTaskBudget {
   /**
    * Remaining token budget. Claude will stop generating once this reaches zero.
    */
-  remaining: number;
+  remaining?: number;
 }
 
 export interface BetaPlainTextSource {

--- a/src/resources/index.ts
+++ b/src/resources/index.ts
@@ -93,6 +93,7 @@ export {
   type Metadata,
   type Model,
   type OutputConfig,
+  type OutputConfigTaskBudget,
   type PlainTextSource,
   type RawContentBlockDelta,
   type RawContentBlockDeltaEvent,

--- a/src/resources/messages/index.ts
+++ b/src/resources/messages/index.ts
@@ -84,6 +84,7 @@ export {
   type Metadata,
   type Model,
   type OutputConfig,
+  type OutputConfigTaskBudget,
   type PlainTextSource,
   type RawContentBlockDelta,
   type RawContentBlockDeltaEvent,

--- a/src/resources/messages/messages.ts
+++ b/src/resources/messages/messages.ts
@@ -33,6 +33,29 @@ import * as MessagesAPI from './messages';
 
 import { MODEL_NONSTREAMING_TOKENS } from '../../internal/constants';
 
+/**
+ * Returns true if any cache_control block in the request has scope: 'global'.
+ * Used to auto-inject the prompt-caching-scope-2026-01-05 beta header.
+ */
+function hasGlobalCacheScope(body: MessageCreateParams): boolean {
+  const isGlobal = (cc: unknown): boolean =>
+    cc != null && typeof cc === 'object' && (cc as Record<string, unknown>)['scope'] === 'global';
+
+  if (Array.isArray(body.system)) {
+    if (body.system.some((b) => isGlobal((b as { cache_control?: unknown }).cache_control))) return true;
+  }
+  if (Array.isArray(body.tools)) {
+    if (body.tools.some((t) => isGlobal((t as { cache_control?: unknown }).cache_control))) return true;
+  }
+  for (const message of body.messages ?? []) {
+    const content = message.content;
+    if (Array.isArray(content)) {
+      if (content.some((b) => isGlobal((b as { cache_control?: unknown }).cache_control))) return true;
+    }
+  }
+  return false;
+}
+
 export class Messages extends APIResource {
   batches: BatchesAPI.Batches = new BatchesAPI.Batches(this._client);
 
@@ -91,6 +114,13 @@ export class Messages extends APIResource {
       timeout = this._client.calculateNonstreamingTimeout(body.max_tokens, maxNonstreamingTokens);
     }
 
+    // Auto-inject required beta headers for fields that have implicit beta requirements.
+    // Explicit options.headers (processed last in buildHeaders) take precedence, matching
+    // the same override semantics as the beta Messages path.
+    const autoBetas: string[] = [];
+    if (body.output_config?.task_budget) autoBetas.push('task-budgets-2026-03-13');
+    if (hasGlobalCacheScope(body)) autoBetas.push('prompt-caching-scope-2026-01-05');
+
     // Collect helper info from tools and messages
     const helperHeader = stainlessHelperHeader(body.tools, body.messages);
 
@@ -98,7 +128,11 @@ export class Messages extends APIResource {
       body,
       timeout: timeout ?? 600000,
       ...options,
-      headers: buildHeaders([helperHeader, options?.headers]),
+      headers: buildHeaders([
+        autoBetas.length > 0 ? { 'anthropic-beta': autoBetas.toString() } : undefined,
+        helperHeader,
+        options?.headers,
+      ]),
       stream: body.stream ?? false,
     }) as APIPromise<Message> | APIPromise<Stream<RawMessageStreamEvent>>;
   }
@@ -1132,7 +1166,7 @@ export interface OutputConfigTaskBudget {
   /**
    * Remaining token budget. Claude will stop generating once this reaches zero.
    */
-  remaining: number;
+  remaining?: number;
 }
 
 const DEPRECATED_MODELS: {

--- a/src/resources/messages/messages.ts
+++ b/src/resources/messages/messages.ts
@@ -292,6 +292,13 @@ export interface CacheControlEphemeral {
    * Defaults to `5m`.
    */
   ttl?: '5m' | '1h';
+
+  /**
+   * Cache scope. When set to `'global'`, the cache entry is shared across all API
+   * requests using the same content, regardless of session. Requires the
+   * `prompt-caching-scope-2026-01-05` beta header.
+   */
+  scope?: 'global';
 }
 
 export interface CacheCreation {
@@ -1103,6 +1110,29 @@ export interface OutputConfig {
    * [structured outputs](https://platform.claude.com/docs/en/build-with-claude/structured-outputs)
    */
   format?: JSONOutputFormat | null;
+
+  /**
+   * Token budget for this task. When provided with the `task-budgets-2026-03-13`
+   * beta, Claude will stop generating output once the remaining budget reaches zero.
+   */
+  task_budget?: OutputConfigTaskBudget | null;
+}
+
+export interface OutputConfigTaskBudget {
+  /**
+   * The type of budget unit.
+   */
+  type: 'tokens';
+
+  /**
+   * Total token budget allocated for this task.
+   */
+  total: number;
+
+  /**
+   * Remaining token budget. Claude will stop generating once this reaches zero.
+   */
+  remaining: number;
 }
 
 const DEPRECATED_MODELS: {
@@ -3240,6 +3270,7 @@ export declare namespace Messages {
     type Metadata as Metadata,
     type Model as Model,
     type OutputConfig as OutputConfig,
+    type OutputConfigTaskBudget as OutputConfigTaskBudget,
     type PlainTextSource as PlainTextSource,
     type RawContentBlockDelta as RawContentBlockDelta,
     type RawContentBlockDeltaEvent as RawContentBlockDeltaEvent,


### PR DESCRIPTION
## What

Adds support for three new beta API features, plus code-review fixes applied on top.

---

### Feature (`f344251`)

- **`AnthropicBeta`**: add `prompt-caching-scope-2026-01-05`, `redact-thinking-2026-02-12`, `token-efficient-tools-2026-03-28`, `task-budgets-2026-03-13`
- **`BetaCacheControlEphemeral` / `CacheControlEphemeral`**: add `scope?: 'global'` — when set, cache entry is shared across sessions. Auto-injects `prompt-caching-scope-2026-01-05` beta header.
- **`BetaOutputConfig` / `OutputConfig`**: add `task_budget?: OutputConfigTaskBudget | null`. Auto-injects `task-budgets-2026-03-13` beta header.
- **`beta Messages.create()`**: auto-inject required beta headers (oauth, task-budgets, prompt-caching-scope) based on request content so callers don't have to track the pairing manually.

---

### Code-review fixes (`4fabc1e`)

**P1 — `parse()` clobbered auto-injected beta headers**

`beta Messages.parse()` was building its own `anthropic-beta` header via `options.headers` before calling `create()`. `buildHeaders` processes header groups left-to-right and clears a key on first encounter per group — so the `options.headers` group (position 3) silently deleted the entire `activeBetas` value assembled by `create()` (position 1). All three auto-injected betas were absent from every `parse()` request.

_Fix:_ inject `structured-outputs-2025-12-15` through `params.betas` instead, so `create()` remains the single place that assembles the complete `anthropic-beta` header.

**P2a — `remaining` required on request-body type**

`OutputConfigTaskBudget.remaining` was non-optional on a type used in the request body. A first-turn caller has no sensible value to provide (it should equal `total`), and `remaining: 0` silently produced zero output with no error.

_Fix:_ `remaining?: number`.

**P2b — non-beta `Messages.create()` never sent required beta headers**

`OutputConfig.task_budget` and `CacheControlEphemeral.scope: 'global'` were added to the non-beta type surface, but the non-beta `create()` had no header-injection logic. Callers using the non-beta path with either field would get API errors with no SDK guidance.

_Fix:_ added `hasGlobalCacheScope()` and auto-injection in the non-beta path, matching the beta path's logic and override semantics.

**Minor:** `any` casts in `hasGlobalCacheScope()` replaced with `{ cache_control?: unknown }` narrowing; extra blank line after `hasGlobalCacheScope` removed; added comment explaining the `(this._client as any).authToken` cast necessity.

---

## Tests

37/37 suites, 584 passed, 1 skipped (pre-existing).