### PR TITLE
fix: preserve directory paths in multipart uploads

### DIFF
--- a/src/internal/uploads.ts
+++ b/src/internal/uploads.ts
@@ -83,7 +83,7 @@ type MultipartFormRequestOptions = Omit<RequestOptions, 'body'> & { body: unknow
 export const multipartFormRequestOptions = async (
   opts: MultipartFormRequestOptions,
   fetch: BaseAnthropic | Fetch,
-  stripFilenames: boolean = true,
+  stripFilenames: boolean = false,
 ): Promise<RequestOptions> => {
   return { ...opts, body: await createForm(opts.body, fetch, stripFilenames) };
 };
@@ -123,7 +123,7 @@ function supportsFormData(fetchObject: BaseAnthropic | Fetch): Promise<boolean> 
 export const createForm = async <T = Record<string, unknown>>(
   body: T | undefined,
   fetch: BaseAnthropic | Fetch,
-  stripFilenames: boolean = true,
+  stripFilenames: boolean = false,
 ): Promise<FormData> => {
   if (!(await supportsFormData(fetch))) {
     throw new TypeError(


### PR DESCRIPTION
## Problem

The SDK's multipart form handling strips directory paths from filenames when uploading files. The `getName` function in `internal/uploads.ts` uses `stripPath=true` by default in `createForm` and `multipartFormRequestOptions`.

This breaks `client.beta.skills.versions.create()` which requires `SKILL.md` to be inside a top-level directory (e.g. `my-skill/SKILL.md`).

## Solution

Change the default value of `stripFilenames` from `true` to `false` in both `createForm` and `multipartFormRequestOptions`.

## Related Issue

Fixes anthropics/anthropic-sdk-typescript#968