### PR TITLE
fix(examples): update deprecated model IDs in tools-helpers examples

### DIFF
--- a/examples/tools-helpers-advanced-streaming.ts
+++ b/examples/tools-helpers-advanced-streaming.ts
@@ -48,7 +48,7 @@ async function main() {
         },
       }),
     ],
-    model: 'claude-3-5-sonnet-latest',
+    model: 'claude-sonnet-4-5-20250929',
     max_tokens: 1024,
     // This limits the conversation to at most 10 back and forth between the API.
     max_iterations: 10,

--- a/examples/tools-helpers-advanced.ts
+++ b/examples/tools-helpers-advanced.ts
@@ -48,7 +48,7 @@ async function main() {
         },
       }),
     ],
-    model: 'claude-3-5-sonnet-latest',
+    model: 'claude-sonnet-4-5-20250929',
     max_tokens: 1024,
     // This limits the conversation to at most 10 back and forth between the API.
     max_iterations: 10,

--- a/examples/tools-helpers-json-schema.ts
+++ b/examples/tools-helpers-json-schema.ts
@@ -32,7 +32,7 @@ async function main() {
         },
       }),
     ],
-    model: 'claude-3-5-sonnet-latest',
+    model: 'claude-sonnet-4-5-20250929',
     max_tokens: 1024,
     // the maximum number of iterations to run the tool
     max_iterations: 10,

--- a/examples/tools-helpers-zod.ts
+++ b/examples/tools-helpers-zod.ts
@@ -26,7 +26,7 @@ async function main() {
         },
       }),
     ],
-    model: 'claude-3-5-sonnet-latest',
+    model: 'claude-sonnet-4-5-20250929',
     max_tokens: 1024,
     // the maximum number of iterations to run the tool
     max_iterations: 10,


### PR DESCRIPTION
## Summary

- Update 4 tools-helpers examples from `claude-3-5-sonnet-latest` to `claude-sonnet-4-5-20250929`
- These were the only examples still using the deprecated 3.5 model ID

**Files changed:**
- `examples/tools-helpers-advanced-streaming.ts`
- `examples/tools-helpers-advanced.ts`
- `examples/tools-helpers-json-schema.ts`
- `examples/tools-helpers-zod.ts`