### PR TITLE
fix: handle invalid JSON escape sequences in partial-json-parser

### DIFF
--- a/src/_vendor/partial-json-parser/parser.ts
+++ b/src/_vendor/partial-json-parser/parser.ts
@@ -249,7 +249,9 @@ const tokenize = (input: string): Token[] => {
     tokens.map((token) => {
       switch (token.type) {
         case 'string':
-          output += '"' + token.value + '"';
+          // Repair invalid JSON escape sequences (e.g. \H from PHP namespaces)
+          // by doubling backslashes before characters that are not valid JSON escapes
+          output += '"' + token.value.replace(/\\([^"\\\/bfnrtu])/g, '\\\\$1') + '"';
           break;
         default:
           output += token.value;

--- a/tests/lib/partial-json.test.ts
+++ b/tests/lib/partial-json.test.ts
@@ -78,4 +78,16 @@ describe('partialParse', () => {
   test('deeply nested partial JSON objects', () => {
     expect(partialParse(`{"a": {"b": {"c": {"d": "e`)).toEqual({ a: { b: { c: {} } } });
   });
+
+  test('string with invalid JSON escape sequences (e.g. PHP namespaces)', () => {
+    expect(partialParse(`{"code": "use App\\Http\\Middleware"}`)).toEqual({
+      code: 'use App\\Http\\Middleware',
+    });
+  });
+
+  test('string with mixed valid and invalid escape sequences', () => {
+    expect(partialParse(`{"text": "line1\\nApp\\Http\\nline2"}`)).toEqual({
+      text: 'line1\nApp\\Http\nline2',
+    });
+  });
 });


### PR DESCRIPTION
## Summary

Fix `partialParse` crashing on invalid JSON escape sequences (e.g. `\H`, `\M` from PHP namespaces like `App\Http\Middleware`) by repairing them in the `generate()` function before `JSON.parse()`.

Fixes #986

## Problem

When a model emits tool call JSON containing unescaped backslashes (e.g. PHP namespaces), `partialParse` throws `Bad escaped character in JSON`, crashing `MessageStream` during `input_json_delta` accumulation and killing the entire streaming response.

The tokeniser correctly captures escape sequences like `\H`, but `generate()` outputs them verbatim into a JSON string. `JSON.parse()` then rejects them since only `\" \\ \/ \b \f \n \r \t \uXXXX` are valid JSON escapes.

## Fix

In `generate()`, sanitise string token values by doubling backslashes before invalid escape characters:

```ts
token.value.replace(/\\([^"\\\/bfnrtu])/g, '\\\\$1')
```

This turns `\H` into `\\H`, `\M` into `\\M`, etc., producing valid JSON.

## Changes

- `src/_vendor/partial-json-parser/parser.ts`: Sanitise invalid escapes in `generate()`
- `tests/lib/partial-json.test.ts`: Added tests for invalid escape sequences and mixed valid/invalid escapes

## Test plan

- [x] All 19 partial-json tests pass (17 existing + 2 new)
- [x] New test: PHP namespace backslashes (`App\Http\Middleware`) parse correctly
- [x] New test: Mixed valid (`\n`) and invalid (`\H`) escapes in same string