### PR TITLE
docs(changelog): fix broken compare links in root changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -802,7 +802,7 @@ Full Changelog: [sdk-v0.50.0...sdk-v0.50.1](https://github.com/anthropics/anthro
 
 ## 0.50.0 (2025-05-09)
 
-Full Changelog: [sdk-v0.41.0...sdk-v0.50.0](https://github.com/anthropics/anthropic-sdk-typescript/compare/sdk-v0.41.0...sdk-v0.42.0)
+Full Changelog: [sdk-v0.41.0...sdk-v0.50.0](https://github.com/anthropics/anthropic-sdk-typescript/compare/sdk-v0.41.0...sdk-v0.50.0)
 
 ### Features
 
@@ -1912,7 +1912,7 @@ Full Changelog: [sdk-v0.12.4...sdk-v0.12.5](https://github.com/anthropics/anthro
 
 ## 0.12.4 (2024-01-23)
 
-Full Changelog: [sdk-v0.12.3...sdk-v0.12.4](https://github.com/anthropics/anthropic-sdk-typescript/compare/sdk-v0.12.3...sdk-v0.12.4)
+Full Changelog: [v0.12.3...sdk-v0.12.4](https://github.com/anthropics/anthropic-sdk-typescript/compare/v0.12.3...sdk-v0.12.4)
 
 ### Chores
 


### PR DESCRIPTION
## Summary
- fix two invalid compare links in root `CHANGELOG.md`
  - `sdk-v0.41.0...sdk-v0.50.0` now points to the correct comparison URL
  - `0.12.4` entry now compares from existing `v0.12.3` tag to `sdk-v0.12.4`

## Why
These entries currently lead to broken compare pages and make release history navigation harder.

Part of #875
