### PR TITLE
perf: fix O(N^2) accumulation in MessageStream and BetaMessageStream

### DIFF
--- a/src/lib/BetaMessageStream.ts
+++ b/src/lib/BetaMessageStream.ts
@@ -611,40 +611,39 @@ export class BetaMessageStream<ParsedT = null> implements AsyncIterable<BetaMess
         switch (event.delta.type) {
           case 'text_delta': {
             if (snapshotContent?.type === 'text') {
-              snapshot.content[event.index] = {
-                ...snapshotContent,
-                text: (snapshotContent.text || '') + event.delta.text,
-              };
+              snapshotContent.text = (snapshotContent.text || '') + event.delta.text;
             }
             break;
           }
           case 'citations_delta': {
             if (snapshotContent?.type === 'text') {
-              snapshot.content[event.index] = {
-                ...snapshotContent,
-                citations: [...(snapshotContent.citations ?? []), event.delta.citation],
-              };
+              if (!snapshotContent.citations) {
+                snapshotContent.citations = [];
+              }
+              snapshotContent.citations.push(event.delta.citation);
             }
             break;
           }
           case 'input_json_delta': {
             if (snapshotContent && tracksToolInput(snapshotContent)) {
-              // we need to keep track of the raw JSON string as well so that we can
-              // re-parse it for each delta, for now we just store it as an untyped
-              // non-enumerable property on the snapshot
+              // Track the raw JSON string as a non-enumerable property so it's
+              // hidden from JSON.stringify/serialization but available for re-parsing
               let jsonBuf = (snapshotContent as any)[JSON_BUF_PROPERTY] || '';
               jsonBuf += event.delta.partial_json;
 
-              const newContent = { ...snapshotContent };
-              Object.defineProperty(newContent, JSON_BUF_PROPERTY, {
-                value: jsonBuf,
-                enumerable: false,
-                writable: true,
-              });
+              if (!(JSON_BUF_PROPERTY in snapshotContent)) {
+                Object.defineProperty(snapshotContent, JSON_BUF_PROPERTY, {
+                  value: jsonBuf,
+                  enumerable: false,
+                  writable: true,
+                });
+              } else {
+                (snapshotContent as any)[JSON_BUF_PROPERTY] = jsonBuf;
+              }
 
               if (jsonBuf) {
                 try {
-                  newContent.input = partialParse(jsonBuf);
+                  (snapshotContent as any).input = partialParse(jsonBuf);
                 } catch (err) {
                   const error = new AnthropicError(
                     `Unable to parse tool parameter JSON from model. Please retry your request or adjust your prompt. Error: ${err}. JSON: ${jsonBuf}`,
@@ -652,34 +651,24 @@ export class BetaMessageStream<ParsedT = null> implements AsyncIterable<BetaMess
                   this.#handleError(error);
                 }
               }
-              snapshot.content[event.index] = newContent;
             }
             break;
           }
           case 'thinking_delta': {
             if (snapshotContent?.type === 'thinking') {
-              snapshot.content[event.index] = {
-                ...snapshotContent,
-                thinking: snapshotContent.thinking + event.delta.thinking,
-              };
+              snapshotContent.thinking = snapshotContent.thinking + event.delta.thinking;
             }
             break;
           }
           case 'signature_delta': {
             if (snapshotContent?.type === 'thinking') {
-              snapshot.content[event.index] = {
-                ...snapshotContent,
-                signature: event.delta.signature,
-              };
+              snapshotContent.signature = event.delta.signature;
             }
             break;
           }
           case 'compaction_delta': {
             if (snapshotContent?.type === 'compaction') {
-              snapshot.content[event.index] = {
-                ...snapshotContent,
-                content: (snapshotContent.content || '') + event.delta.content,
-              };
+              snapshotContent.content = (snapshotContent.content || '') + event.delta.content;
             }
             break;
           }

--- a/src/lib/BetaMessageStream.ts
+++ b/src/lib/BetaMessageStream.ts
@@ -603,7 +603,7 @@ export class BetaMessageStream<ParsedT = null> implements AsyncIterable<BetaMess
 
         return snapshot;
       case 'content_block_start':
-        snapshot.content.push(event.content_block);
+        snapshot.content.push({ ...event.content_block });
         return snapshot;
       case 'content_block_delta': {
         const snapshotContent = snapshot.content.at(event.index);

--- a/src/lib/MessageStream.ts
+++ b/src/lib/MessageStream.ts
@@ -605,59 +605,51 @@ export class MessageStream<ParsedT = null> implements AsyncIterable<MessageStrea
         switch (event.delta.type) {
           case 'text_delta': {
             if (snapshotContent?.type === 'text') {
-              snapshot.content[event.index] = {
-                ...snapshotContent,
-                text: (snapshotContent.text || '') + event.delta.text,
-              };
+              snapshotContent.text = (snapshotContent.text || '') + event.delta.text;
             }
             break;
           }
           case 'citations_delta': {
             if (snapshotContent?.type === 'text') {
-              snapshot.content[event.index] = {
-                ...snapshotContent,
-                citations: [...(snapshotContent.citations ?? []), event.delta.citation],
-              };
+              if (!snapshotContent.citations) {
+                snapshotContent.citations = [];
+              }
+              snapshotContent.citations.push(event.delta.citation);
             }
             break;
           }
           case 'input_json_delta': {
             if (snapshotContent && tracksToolInput(snapshotContent)) {
-              // we need to keep track of the raw JSON string as well so that we can
-              // re-parse it for each delta, for now we just store it as an untyped
-              // non-enumerable property on the snapshot
+              // Track the raw JSON string as a non-enumerable property so it's
+              // hidden from JSON.stringify/serialization but available for re-parsing
               let jsonBuf = (snapshotContent as any)[JSON_BUF_PROPERTY] || '';
               jsonBuf += event.delta.partial_json;
 
-              const newContent = { ...snapshotContent };
-              Object.defineProperty(newContent, JSON_BUF_PROPERTY, {
-                value: jsonBuf,
-                enumerable: false,
-                writable: true,
-              });
+              if (!(JSON_BUF_PROPERTY in snapshotContent)) {
+                Object.defineProperty(snapshotContent, JSON_BUF_PROPERTY, {
+                  value: jsonBuf,
+                  enumerable: false,
+                  writable: true,
+                });
+              } else {
+                (snapshotContent as any)[JSON_BUF_PROPERTY] = jsonBuf;
+              }
 
               if (jsonBuf) {
-                newContent.input = partialParse(jsonBuf);
+                (snapshotContent as any).input = partialParse(jsonBuf);
               }
-              snapshot.content[event.index] = newContent;
             }
             break;
           }
           case 'thinking_delta': {
             if (snapshotContent?.type === 'thinking') {
-              snapshot.content[event.index] = {
-                ...snapshotContent,
-                thinking: snapshotContent.thinking + event.delta.thinking,
-              };
+              snapshotContent.thinking = snapshotContent.thinking + event.delta.thinking;
             }
             break;
           }
           case 'signature_delta': {
             if (snapshotContent?.type === 'thinking') {
-              snapshot.content[event.index] = {
-                ...snapshotContent,
-                signature: event.delta.signature,
-              };
+              snapshotContent.signature = event.delta.signature;
             }
             break;
           }

--- a/tests/api-resources/MessageStream.test.ts
+++ b/tests/api-resources/MessageStream.test.ts
@@ -226,6 +226,69 @@ describe('MessageStream class', () => {
     expect(finalText).toBe("I'll check the current weather in Paris for you.");
   });
 
+  it('accumulates large text responses in linear time', async () => {
+    const { fetch, handleStreamEvents } = mockFetch();
+
+    const anthropic = new Anthropic({ apiKey: '...', fetch });
+
+    const NUM_DELTAS = 5000;
+    const CHUNK = 'abcdefghij'; // 10 chars per delta
+
+    // Build a synthetic stream with many text deltas
+    const events: any[] = [
+      {
+        type: 'message_start',
+        message: {
+          id: 'msg_perf_test',
+          type: 'message',
+          role: 'assistant',
+          content: [],
+          model: 'claude-opus-4-20250514',
+          stop_reason: null,
+          stop_sequence: null,
+          usage: { input_tokens: 10, output_tokens: 1 },
+        },
+      },
+      {
+        type: 'content_block_start',
+        index: 0,
+        content_block: { type: 'text', text: '' },
+      },
+    ];
+
+    for (let i = 0; i < NUM_DELTAS; i++) {
+      events.push({
+        type: 'content_block_delta',
+        index: 0,
+        delta: { type: 'text_delta', text: CHUNK },
+      });
+    }
+
+    events.push(
+      { type: 'content_block_stop', index: 0 },
+      { type: 'message_delta', delta: { stop_reason: 'end_turn', stop_sequence: null }, usage: { output_tokens: NUM_DELTAS } },
+      { type: 'message_stop' },
+    );
+
+    handleStreamEvents(events);
+
+    const stream = anthropic.messages.stream({
+      max_tokens: 1024,
+      model: 'claude-opus-4-20250514',
+      messages: [{ role: 'user', content: 'test' }],
+    });
+
+    const finalMessage = await stream.finalMessage();
+    const finalText = await stream.finalText();
+
+    // Verify correctness
+    expect(finalText).toBe(CHUNK.repeat(NUM_DELTAS));
+    expect(finalMessage.content[0]!.type).toBe('text');
+    if (finalMessage.content[0]!.type === 'text') {
+      expect(finalMessage.content[0]!.text).toBe(CHUNK.repeat(NUM_DELTAS));
+    }
+  });
+
   it('does not throw unhandled rejection with withResponse()', async () => {
     const { fetch, handleRequest } = mockFetch();
     const anthropic = new Anthropic({


### PR DESCRIPTION
## Summary

Replaces object spread with direct in-place mutation in `#accumulateMessage` for all `content_block_delta` types in both `MessageStream` and `BetaMessageStream`. The previous implementation created a new content block object via `{ ...snapshotContent, prop: newValue }` on every delta event, causing O(N^2) work for N deltas.

**Delta types fixed:**
- `text_delta`: `{ ...obj, text: old + new }` → `obj.text = old + new`
- `citations_delta`: `[...existing, new]` → `Array.push()` (O(N^2) → O(N) for array copy)
- `input_json_delta`: spread + `defineProperty` each time → `defineProperty` once, then direct assignment
- `thinking_delta`: `{ ...obj, thinking: old + new }` → `obj.thinking = old + new`
- `signature_delta`: `{ ...obj, signature: val }` → `obj.signature = val`
- `compaction_delta` (Beta only): `{ ...obj, content: old + new }` → `obj.content = old + new`

**Why this is safe:** The `message_delta` case already uses direct mutation (`snapshot.stop_reason = event.delta.stop_reason`). All content block TypeScript types are mutable interfaces (no `readonly` modifiers). The snapshot is stored in a private field and events emit references to the same object.

**Also fixes:** BetaMessageStream's `content_block_start` was missing the defensive copy (`{ ...event.content_block }`) that MessageStream has. Added for consistency since we now mutate content blocks in place.

Fixes #995
Fixes #933

## Relationship to PR #936

PR #936 addresses only `input_json_delta` with a lazy getter approach. This PR fixes all 6 delta types in both files using a simpler, consistent mutation pattern.

## Test plan

- [x] All existing tests pass (`MessageStream.test.ts`, `BetaMessageStream.test.ts`, `streaming.test.ts`)
- [x] Added test: "accumulates large text responses in linear time" — streams 5,000 text deltas and verifies correct accumulation
- [x] `tsc --noEmit` passes with no type errors