### PR TITLE
fix(stream): handle invalid JSON escape sequences in MessageStream

### DIFF
--- a/src/lib/MessageStream.ts
+++ b/src/lib/MessageStream.ts
@@ -637,7 +637,11 @@ export class MessageStream<ParsedT = null> implements AsyncIterable<MessageStrea
               });
 
               if (jsonBuf) {
-                newContent.input = partialParse(jsonBuf);
+                try {
+                  newContent.input = partialParse(jsonBuf);
+                } catch {
+                  // invalid escape sequences (e.g. \d, \p, \s) — skip this delta, stream continues
+                }
               }
               snapshot.content[event.index] = newContent;
             }


### PR DESCRIPTION
## Summary

Fixes #996

When the Anthropic API streams tool-use deltas containing invalid JSON escape sequences (e.g. `\d`, `\p`, `\s` from regex patterns), `partialParse()` throws an unhandled error that crashes the entire `MessageStream`. This is a runtime crash with no way for consumers to recover gracefully.

## Change

Wrapped the `partialParse(jsonBuf)` call in `#accumulateMessage` with a try-catch that silently skips the delta on parse failure. The stream continues processing subsequent events, and the final complete JSON (which uses proper `\\d` escaping) parses correctly.

**Before:**
```typescript
newContent.input = partialParse(jsonBuf);
```

**After:**
```typescript
try {
  newContent.input = partialParse(jsonBuf);
} catch {
  // invalid escape sequences (e.g. \d, \p, \s) — skip this delta, stream continues
}
```

This is the minimal surgical fix — one file changed, 5 lines added, 1 removed.

## Verification

- `tsc --noEmit` passes (EXIT_CODE=0)
- `npm test` passes (641 passed, 5 failed pre-existing Nock connection errors in ToolRunnerE2E unrelated to this change)