### PR TITLE
fix(build): rewrite block-comment @ts-ignore to line-comment form in dist declaration files

### DIFF
--- a/scripts/utils/postprocess-files.cjs
+++ b/scripts/utils/postprocess-files.cjs
@@ -23,11 +23,25 @@ async function postprocess() {
 
     // strip out lib="dom", types="node", and types="react" references; these
     // are needed at build time, but would pollute the user's TS environment
-    const transformed = code.replace(
+    let transformed = code.replace(
       /^ *\/\/\/ *<reference +(lib="dom"|types="(node|react)").*?\n/gm,
       // replace with same number of characters to avoid breaking source maps
       (match) => ' '.repeat(match.length - 1) + '\n',
     );
+
+    // In emitted declaration files, TypeScript collapses `/** @ts-ignore <msg> */`
+    // and the following declaration onto a single line.  A block comment on the same
+    // line as the declaration has no suppression effect; TypeScript only recognises
+    // the single-line `// @ts-ignore` form on its own line immediately before the
+    // offending statement.  Rewrite every occurrence so that the directive is on its
+    // own preceding line, which avoids spurious TS2307 errors for users who don't have
+    // optional peer dependencies (undici, node-fetch, …) installed.
+    if (/\.d\.[cm]?ts$/.test(file)) {
+      transformed = transformed.replace(
+        /\/\*\*\s*@ts-ignore\s+(.*?)\s*\*\/[ \t]*\n?/g,
+        (_, msg) => `// @ts-ignore${msg.trim() ? ' ' + msg.trim() : ''}\n`,
+      );
+    }
 
     if (transformed !== code) {
       console.error(`wrote ${path.relative(process.cwd(), file)}`);


### PR DESCRIPTION
## Summary

Fixes #1022.

TypeScript only recognises the single-line `// @ts-ignore` comment form as an error-suppression directive.  When generating declaration files, the TypeScript compiler collapses a JSDoc block comment (`/** @ts-ignore <msg> */`) and the declaration that immediately follows it onto a **single line**.  A block comment on the same line as the offending declaration has no suppression effect, causing spurious `TS2307` errors like:

```
node_modules/@anthropic-ai/sdk/internal/types.d.ts:48:181 - error TS2307:
Cannot find module '../../../node_modules/undici-types/index.d.ts' or
its corresponding type declarations.
```

These errors affect users who do not have optional peer dependencies (undici, node-fetch, …) installed.

## Fix

Add a postprocess step in `scripts/utils/postprocess-files.cjs` that rewrites every `/** @ts-ignore <msg> */` occurrence in emitted `.d.ts` / `.d.mts` / `.d.cts` declaration files to the `// @ts-ignore <msg>` line-comment form on its own preceding line — the form that TypeScript's error-suppression logic actually recognises.

**Before** (generated `.d.ts`):
```ts
/** @ts-ignore For users with \@types/node */ type UndiciTypesRequestInit = NotAny<…>;
```

**After** (generated `.d.ts`):
```ts
// @ts-ignore For users with \@types/node
type UndiciTypesRequestInit = NotAny<…>;
```

The transformation is scoped to `*.d.[cm]?ts` files only, so source copies in `dist/src/` are left untouched.

## Test plan

- [x] `./scripts/build` completes with zero TypeScript errors
- [x] `dist/internal/types.d.ts` and `dist/internal/types.d.mts` now have `// @ts-ignore` on a separate line before each affected type alias
- [x] `dist/internal/shim-types.d.ts` and `.d.mts` now have `// @ts-ignore` on a separate line before each affected type alias
- [x] `node -e 'require("@anthropic-ai/sdk")'` and ESM import still succeed

https://claude.ai/code/session_01T8f8SVd3zUdGd8WwocA8Ck