### PR TITLE
fix(base64): process large arrays in chunks to avoid call stack overflow

### DIFF
--- a/src/internal/utils/base64.ts
+++ b/src/internal/utils/base64.ts
@@ -15,7 +15,14 @@ export const toBase64 = (data: string | Uint8Array | null | undefined): string =
   }
 
   if (typeof btoa !== 'undefined') {
-    return btoa(String.fromCharCode.apply(null, data as any));
+    // String.fromCharCode.apply with a large array overflows the call stack,
+    // so process in chunks instead.
+    let binary = '';
+    const chunkSize = 8192;
+    for (let i = 0; i < data.length; i += chunkSize) {
+      binary += String.fromCharCode.apply(null, data.subarray(i, i + chunkSize) as any);
+    }
+    return btoa(binary);
   }
 
   throw new AnthropicError('Cannot generate base64 string; Expected `Buffer` or `btoa` to be defined');

--- a/tests/base64.test.ts
+++ b/tests/base64.test.ts
@@ -50,6 +50,17 @@ describe.each(['Buffer', 'atob'])('with %s', (mode) => {
     });
   });
 
+  test('toBase64 does not stack-overflow on large inputs', () => {
+    // 200 KB — large enough to exceed the call stack with .apply(null, array)
+    const large = new Uint8Array(200 * 1024);
+    for (let i = 0; i < large.length; i++) large[i] = i & 0xff;
+    const result = toBase64(large);
+    expect(typeof result).toBe('string');
+    expect(result.length).toBeGreaterThan(0);
+    // Round-trip check
+    expect(fromBase64(result)).toEqual(large);
+  });
+
   test('fromBase64', () => {
     const testCases = [
       {


### PR DESCRIPTION
## Summary

- `String.fromCharCode.apply(null, largeArray)` spreads the entire `Uint8Array` as function arguments, which exceeds the JS engine call stack limit for inputs larger than ~100 KB in non-Node environments (browsers, Cloudflare Workers, Deno)
- Replace with a chunked loop (8 KB per chunk) that stays well within stack limits
- Round-trip test added covering a 200 KB input in both `Buffer` and `atob` modes

Fixes #932