### PR TITLE
fix(types): make betaZodTool return type assignable to ToolUnion

### DIFF
--- a/src/helpers/beta/zod.ts
+++ b/src/helpers/beta/zod.ts
@@ -3,7 +3,8 @@ import type { infer as zodInfer, ZodType } from 'zod';
 import * as z from 'zod/v4';
 import { AnthropicError } from '../../core/error';
 import { AutoParseableBetaOutputFormat } from '../../lib/beta-parser';
-import { BetaRunnableTool, BetaToolRunContext, Promisable } from '../../lib/tools/BetaRunnableTool';
+import { BetaRunnableCustomTool, BetaToolRunContext, Promisable } from '../../lib/tools/BetaRunnableTool';
+export type { BetaRunnableCustomTool } from '../../lib/tools/BetaRunnableTool';
 import { BetaToolResultContentBlockParam } from '../../resources/beta';
 /**
  * Creates a JSON schema output format object from the given Zod schema.
@@ -54,7 +55,7 @@ export function betaZodTool<InputSchema extends ZodType>(options: {
     args: zodInfer<InputSchema>,
     context?: BetaToolRunContext,
   ) => Promisable<string | Array<BetaToolResultContentBlockParam>>;
-}): BetaRunnableTool<zodInfer<InputSchema>> {
+}): BetaRunnableCustomTool<zodInfer<InputSchema>> {
   const jsonSchema = z.toJSONSchema(options.inputSchema, { reused: 'ref' });
 
   if (jsonSchema.type !== 'object') {

--- a/src/lib/tools/BetaRunnableTool.ts
+++ b/src/lib/tools/BetaRunnableTool.ts
@@ -47,3 +47,31 @@ export type BetaRunnableTool<Input = any> = BetaClientRunnableToolType & {
   ) => Promisable<string | Array<BetaToolResultContentBlockParam>>;
   parse: (content: unknown) => Input;
 };
+
+/**
+ * A runnable custom tool (type: 'custom') created by helpers like `betaZodTool`.
+ *
+ * Unlike the more general {@link BetaRunnableTool}, this type is structurally
+ * compatible with `ToolUnion` so it can be passed directly to
+ * `client.messages.stream()` and `client.messages.create()` in addition to
+ * `client.beta.messages.toolRunner()`.
+ *
+ * The narrower `input_schema` shape (no `readonly` arrays) is what makes the
+ * assignability work under `strictNullChecks` + `exactOptionalPropertyTypes`.
+ */
+export type BetaRunnableCustomTool<Input = any> = {
+  type: 'custom';
+  name: string;
+  description?: string;
+  input_schema: {
+    type: 'object';
+    properties?: unknown | null;
+    required?: string[] | null;
+    [k: string]: unknown;
+  };
+  run: (
+    args: Input,
+    context?: BetaToolRunContext,
+  ) => Promisable<string | Array<BetaToolResultContentBlockParam>>;
+  parse: (content: unknown) => Input;
+};

--- a/tests/helpers/zod.test.ts
+++ b/tests/helpers/zod.test.ts
@@ -1,8 +1,53 @@
 import { z } from 'zod';
-import { betaZodOutputFormat } from '../../src/helpers/beta/zod';
+import type { ToolUnion } from '../../src/resources/messages/messages';
+import { betaZodOutputFormat, betaZodTool } from '../../src/helpers/beta/zod';
 import { zodOutputFormat } from '../../src/helpers/zod';
 
 describe('beta zod helpers', () => {
+  describe('betaZodTool', () => {
+    it('returns a tool that is assignable to ToolUnion (issue #1010)', () => {
+      const tool = betaZodTool({
+        name: 'create_event',
+        description: 'Create a calendar event',
+        inputSchema: z.object({ title: z.string() }),
+        run: async (input) => `Created: ${input.title}`,
+      });
+
+      // Compile-time check: betaZodTool result must be usable as ToolUnion
+      const toolUnion: ToolUnion = tool;
+      expect(toolUnion.name).toBe('create_event');
+    });
+
+    it('generates correct tool definition', () => {
+      const tool = betaZodTool({
+        name: 'my_tool',
+        description: 'A test tool',
+        inputSchema: z.object({ value: z.number() }),
+        run: async (input) => String(input.value),
+      });
+
+      expect(tool.type).toBe('custom');
+      expect(tool.name).toBe('my_tool');
+      expect(tool.description).toBe('A test tool');
+      expect(tool.input_schema.type).toBe('object');
+    });
+
+    it('run and parse methods work correctly', async () => {
+      const tool = betaZodTool({
+        name: 'echo',
+        description: 'Echo a value',
+        inputSchema: z.object({ msg: z.string() }),
+        run: async (input) => `echo: ${input.msg}`,
+      });
+
+      const result = await tool.run({ msg: 'hello' });
+      expect(result).toBe('echo: hello');
+
+      const parsed = tool.parse({ msg: 'world' });
+      expect(parsed).toEqual({ msg: 'world' });
+    });
+  });
+
   describe('betaZodOutputFormat', () => {
     it('creates valid JSON schema from simple Zod object', () => {
       const schema = z.object({


### PR DESCRIPTION
## Summary

`betaZodTool` always creates a custom tool (`type: 'custom'`), but its return type was `BetaRunnableTool<T>` which is `BetaClientRunnableToolType & { run, parse }`. Because `BetaClientRunnableToolType` is a union that distributes through the intersection, TypeScript expands it to `(BetaTool & { run, parse }) | (BetaToolBash & { run, parse }) | ...`. The `BetaTool.InputSchema.required` field is typed as `string[] | readonly string[] | null`, while `Tool.InputSchema.required` (used in the non-beta `ToolUnion`) only allows `string[] | null`. Under `exactOptionalPropertyTypes: true`, `readonly string[]` is not assignable to `Array<string>`, so `BetaRunnableTool<T>` is not assignable to `ToolUnion`, causing TS2322 for anyone trying to pass a `betaZodTool` result to `messages.stream()` or `messages.create()`.

The fix introduces `BetaRunnableCustomTool<T>` — a narrower type specifically for user-defined custom tools. Its `input_schema.required` is `string[] | null` (no `readonly`), making it structurally compatible with both `Tool.InputSchema` (non-beta) and `BetaTool.InputSchema` (beta). `betaZodTool` now returns this type, and it is re-exported from `helpers/beta/zod` so callers can reference it in type annotations. `BetaRunnableTool<T>` is preserved unchanged for existing usages in `betaTool`, `betaJsonSchemaTool`, and the tool-runner internals.

## Issue

Fixes #1010

## Local verification

```
cd /tmp/anthropic-sdk-typescript

# TypeScript typecheck (must pass with zero errors)
./node_modules/.bin/tsc --noEmit
# Output: (empty – exit 0)

# Run the narrowly-scoped test file covering betaZodTool
./node_modules/.bin/jest tests/helpers/zod.test.ts --no-coverage
```

Last lines of output:
```
Test Suites: 1 passed, 1 total
Tests:       23 passed, 23 total
Snapshots:   0 total
Time:        0.359 s
```

=== LOCAL_TEST_PASSED ===

## Risk

This is a **type-only change** with no runtime effect. No compiled JavaScript is modified. The only observable change for users is that `betaZodTool`'s return type becomes `BetaRunnableCustomTool<T>` instead of `BetaRunnableTool<T>`. Because `BetaRunnableCustomTool<T>` is a subtype of `BetaRunnableTool<T>` (all required structural constraints of `BetaRunnableTool` are satisfied), existing code that accepts `BetaRunnableTool<T>` will also accept the new type without modification.
