### PR TITLE
test(tool-runner): regression test for header propagation across iterations

### DIFF
--- a/tests/lib/tools/ToolRunner.test.ts
+++ b/tests/lib/tools/ToolRunner.test.ts
@@ -1469,4 +1469,88 @@ describe('ToolRunner', () => {
       expect(capturedContext!.signal).toBe(controller.signal);
     });
   });
+
+  describe('request headers propagation', () => {
+    it('propagates client.defaultHeaders and options.headers across all iterations of the tool loop', async () => {
+      const { fetch, handleRequest } = mockFetch();
+      const client = new Anthropic({
+        apiKey: 'test-key',
+        fetch,
+        maxRetries: 0,
+        defaultHeaders: { 'x-default-header': 'from-defaultHeaders' },
+      });
+
+      const captured: Array<{ default: string | null; options: string | null }> = [];
+
+      // First response: tool_use forces a follow-up request.
+      handleRequest(async (_req, init) => {
+        const headers = init?.headers;
+        if (headers instanceof Headers) {
+          captured.push({
+            default: headers.get('x-default-header'),
+            options: headers.get('x-options-header'),
+          });
+        }
+        return new Response(
+          JSON.stringify({
+            id: 'msg_1',
+            type: 'message',
+            role: 'assistant',
+            content: [{ type: 'tool_use', id: 'tool_1', name: 'getWeather', input: { location: 'London' } }],
+            model: 'claude-3-5-sonnet-latest',
+            stop_reason: 'tool_use',
+            stop_sequence: null,
+            container: null,
+            context_management: null,
+            usage: { input_tokens: 10, output_tokens: 20 },
+          }),
+          { headers: { 'content-type': 'application/json' } },
+        );
+      });
+
+      // Second response: end_turn closes the loop.
+      handleRequest(async (_req, init) => {
+        const headers = init?.headers;
+        if (headers instanceof Headers) {
+          captured.push({
+            default: headers.get('x-default-header'),
+            options: headers.get('x-options-header'),
+          });
+        }
+        return new Response(
+          JSON.stringify({
+            id: 'msg_2',
+            type: 'message',
+            role: 'assistant',
+            content: [{ type: 'text', text: 'Done!', citations: null }],
+            model: 'claude-3-5-sonnet-latest',
+            stop_reason: 'end_turn',
+            stop_sequence: null,
+            container: null,
+            context_management: null,
+            usage: { input_tokens: 10, output_tokens: 5 },
+          }),
+          { headers: { 'content-type': 'application/json' } },
+        );
+      });
+
+      const runner = client.beta.messages.toolRunner(
+        {
+          model: 'claude-3-5-sonnet-latest',
+          max_tokens: 1000,
+          messages: [{ role: 'user', content: 'What is the weather in London?' }],
+          tools: [weatherTool],
+        },
+        { headers: { 'x-options-header': 'from-options' } },
+      );
+
+      await runner.runUntilDone();
+
+      expect(captured).toHaveLength(2);
+      for (const headers of captured) {
+        expect(headers.default).toBe('from-defaultHeaders');
+        expect(headers.options).toBe('from-options');
+      }
+    });
+  });
 });


### PR DESCRIPTION
Closes #922

## What

Adds a regression test in `tests/lib/tools/ToolRunner.test.ts` verifying that user-provided custom headers — both `client.defaultHeaders` and the `options.headers` passed as the second argument to `client.beta.messages.toolRunner` — propagate to every request in the tool-use loop, not just the first one.

## Why

The original bug in #922 (custom headers dropped on follow-up calls) was fixed in v0.64.0 (commit ac6a7a3) by adding the optional `options` parameter to `BetaToolRunner` and threading `this.#options` through to every `client.beta.messages.{create,stream}` call. However, the existing tests only cover `x-stainless-helper` propagation through iterations — user-provided headers in the multi-iteration path are not exercised. This PR closes that gap so the fix doesn't quietly regress.

## How tested

- `jest tests/lib/tools/ToolRunner.test.ts` — 29 passed (1 new + 28 existing)
- Verified end-to-end against `@anthropic-ai/sdk@0.95.1` with a local mock server: both `defaultHeaders` and `options.headers` arrive on the initial request and on the follow-up after `tool_use`
- `prettier --write` and `eslint --fix` applied; no other changes

## AI disclosure

AI-assisted: used Claude for codebase analysis, identifying the test gap, and drafting the test scaffold. Reasoning and verification reviewed manually.