### PR TITLE
fix(vertex): strip anthropic-beta header from count_tokens requests

### DIFF
--- a/packages/vertex-sdk/src/client.ts
+++ b/packages/vertex-sdk/src/client.ts
@@ -192,6 +192,12 @@ export class AnthropicVertex extends BaseAnthropic {
       }
 
       options.path = `/projects/${this.projectId}/locations/${this.region}/publishers/anthropic/models/count-tokens:rawPredict`;
+
+      // Vertex model backends roll out new beta values on different schedules.
+      // Token counting doesn't require any beta capabilities, so strip the
+      // anthropic-beta header to avoid 400 errors from lagging model tiers
+      // (most notably Haiku) that haven't received a newly-introduced beta yet.
+      options.headers = buildHeaders([options.headers, { 'anthropic-beta': null }]);
     }
 
     return super.buildRequest(options);

--- a/packages/vertex-sdk/tests/client.test.ts
+++ b/packages/vertex-sdk/tests/client.test.ts
@@ -14,7 +14,50 @@ jest.mock('google-auth-library', () => ({
   })),
 }));
 
+const makeClient = (overrides: Partial<ConstructorParameters<typeof AnthropicVertex>[0]> = {}) =>
+  new AnthropicVertex({
+    region: 'us-central1',
+    projectId: 'test-project',
+    accessToken: 'fake-token',
+    ...overrides,
+  });
+
 describe('AnthropicVertex', () => {
+  describe('count_tokens strips anthropic-beta header', () => {
+    test('strips anthropic-beta from /v1/messages/count_tokens', async () => {
+      const client = makeClient();
+      const { req } = await client.buildRequest({
+        method: 'post',
+        path: '/v1/messages/count_tokens',
+        headers: { 'anthropic-beta': 'effort-2025-11-24' },
+        body: { model: 'claude-haiku-4-5', messages: [], max_tokens: 10 },
+      });
+      expect((req.headers as Headers).get('anthropic-beta')).toBeNull();
+    });
+
+    test('strips anthropic-beta from /v1/messages/count_tokens?beta=true', async () => {
+      const client = makeClient();
+      const { req } = await client.buildRequest({
+        method: 'post',
+        path: '/v1/messages/count_tokens?beta=true',
+        headers: { 'anthropic-beta': 'effort-2025-11-24' },
+        body: { model: 'claude-haiku-4-5', messages: [], max_tokens: 10 },
+      });
+      expect((req.headers as Headers).get('anthropic-beta')).toBeNull();
+    });
+
+    test('does NOT strip anthropic-beta from regular /v1/messages requests', async () => {
+      const client = makeClient();
+      const { req } = await client.buildRequest({
+        method: 'post',
+        path: '/v1/messages',
+        headers: { 'anthropic-beta': 'some-feature' },
+        body: { model: 'claude-haiku-4-5', messages: [], max_tokens: 10, stream: false },
+      });
+      expect((req.headers as Headers).get('anthropic-beta')).toBe('some-feature');
+    });
+  });
+
   describe('baseURL configuration', () => {
     test('global region uses correct base URL', () => {
       const client = new AnthropicVertex({


### PR DESCRIPTION
## Summary

When calling `countTokens` through the Vertex AI backend, the SDK forwards `anthropic-beta` headers to the underlying model-specific endpoint. Vertex model backends roll out new beta values on different schedules — the Haiku tier consistently lags — so any call that includes a newly-introduced beta value (e.g. `effort-2025-11-24`, `structured-outputs-2025-12-15`, `web-search-2025-03-05`) is rejected with HTTP 400 by the lagging model endpoint. This causes recurring breakage every time Anthropic introduces a new beta: downstream consumers (including Claude Code, see anthropics/claude-code#11154) have to wait for Vertex's per-model rollout to catch up.

Token counting does not require any beta-gated capabilities. This PR strips the `anthropic-beta` header specifically from `count_tokens` requests in the Vertex SDK using the existing `buildHeaders` null-override mechanism, which is the same pattern already used in `prepareOptions`. Stripping only happens on the count-tokens path, so regular messages requests continue to forward the header as before.

## Issue

Fixes #1016

## Local verification

```
cd packages/vertex-sdk
yarn install --ignore-scripts   # deps already installed in CI
yarn test

PASS tests/client.test.ts
  AnthropicVertex
    count_tokens strips anthropic-beta header
      ✓ strips anthropic-beta from /v1/messages/count_tokens (17 ms)
      ✓ strips anthropic-beta from /v1/messages/count_tokens?beta=true (3 ms)
      ✓ does NOT strip anthropic-beta from regular /v1/messages requests (2 ms)
    baseURL configuration
      ✓ global region uses correct base URL (1 ms)
      ✓ us region uses correct base URL (1 ms)
      ✓ eu region eues correct base URL (1 ms)
      ✓ regional endpoint us-central1 uses correct base URL format (1 ms)
      ✓ regional endpoint europe-west1 uses correct base URL format (1 ms)
      ✓ regional endpoint asia-southeast1 uses correct base URL format (2 ms)
      ✓ explicit baseURL option takes precedence over region (1 ms)
      ✓ throws error when region is not provided (6 ms)

Test Suites: 1 passed, 1 total
Tests:       11 passed, 11 total
Time:        0.347 s
=== LOCAL_TEST_PASSED ===
```

## Risk

The change only affects the `count_tokens` path in the Vertex backend; no other paths are modified. The `anthropic-beta` header is orthogonal to token counting — stripping it cannot change the count result. Users who were deliberately setting `anthropic-beta` on `countTokens` calls (an uncommon pattern, since no beta feature currently affects token counting) will silently have the header dropped, which is the correct behaviour on Vertex where the header triggers errors rather than enabling features.
