### PR TITLE
fix(helpers): give a clear error when a zod v3 schema is passed to the zod helpers

### DIFF
--- a/src/helpers/beta/zod.ts
+++ b/src/helpers/beta/zod.ts
@@ -1,6 +1,7 @@
 import { transformJSONSchema } from '../..//lib/transform-json-schema';
 import * as z from 'zod/v4';
 import { AnthropicError } from '../../core/error';
+import { assertZodV4Schema } from '../../lib/check-zod-version';
 import { AutoParseableBetaOutputFormat } from '../../lib/beta-parser';
 import { BetaRunnableTool, BetaToolRunContext, Promisable } from '../../lib/tools/BetaRunnableTool';
 import { BetaToolResultContentBlockParam } from '../../resources/beta';
@@ -16,6 +17,7 @@ import { BetaToolResultContentBlockParam } from '../../resources/beta';
 export function betaZodOutputFormat<ZodInput extends z.ZodType>(
   zodObject: ZodInput,
 ): AutoParseableBetaOutputFormat<z.infer<ZodInput>> {
+  assertZodV4Schema(zodObject, 'betaZodOutputFormat');
   let jsonSchema = z.toJSONSchema(zodObject, { reused: 'ref' });
 
   jsonSchema = transformJSONSchema(jsonSchema);
@@ -60,6 +62,7 @@ export function betaZodTool<InputSchema extends z.ZodType>(options: {
    */
   close?: () => void | Promise<void>;
 }): BetaRunnableTool<z.infer<InputSchema>> {
+  assertZodV4Schema(options.inputSchema, 'betaZodTool');
   const jsonSchema = z.toJSONSchema(options.inputSchema, { reused: 'ref' });
 
   if (jsonSchema.type !== 'object') {

--- a/src/helpers/zod.ts
+++ b/src/helpers/zod.ts
@@ -1,6 +1,7 @@
 import { transformJSONSchema } from '../lib/transform-json-schema';
 import * as z from 'zod/v4';
 import { AnthropicError } from '../core/error';
+import { assertZodV4Schema } from '../lib/check-zod-version';
 import { AutoParseableOutputFormat } from '../lib/parser';
 
 /**
@@ -15,6 +16,7 @@ import { AutoParseableOutputFormat } from '../lib/parser';
 export function zodOutputFormat<ZodInput extends z.ZodType>(
   zodObject: ZodInput,
 ): AutoParseableOutputFormat<z.infer<ZodInput>> {
+  assertZodV4Schema(zodObject, 'zodOutputFormat');
   let jsonSchema = z.toJSONSchema(zodObject, { reused: 'ref' });
 
   jsonSchema = transformJSONSchema(jsonSchema);

--- a/src/lib/check-zod-version.ts
+++ b/src/lib/check-zod-version.ts
@@ -1,0 +1,22 @@
+import { AnthropicError } from '../core/error';
+
+/**
+ * The SDK's zod helpers call `z.toJSONSchema` from `zod/v4`, which only understands
+ * v4-shaped schemas. Passing a v3 schema (constructed via `import { z } from 'zod'`
+ * against a zod 3.x install) makes `toJSONSchema` throw a confusing internal
+ * `TypeError: Cannot read properties of undefined (reading 'def')`.
+ *
+ * v4 schemas always have a `_zod` property; v3 schemas don't. Detect the case and
+ * throw an actionable error pointing at the two unblock paths.
+ */
+export function assertZodV4Schema(zodObject: unknown, callerName: string): void {
+  if (zodObject && typeof zodObject === 'object' && (zodObject as { _zod?: unknown })._zod !== undefined) {
+    return;
+  }
+
+  throw new AnthropicError(
+    `${callerName} requires a zod v4 schema, but received what appears to be a zod v3 schema. ` +
+      `Either upgrade your project to zod v4, or, if you're on zod >= 3.25, import via ` +
+      `\`import { z } from 'zod/v4'\` (the v4 subpath is shipped as a backport in recent zod 3.x releases).`,
+  );
+}

--- a/tests/helpers/zod.test.ts
+++ b/tests/helpers/zod.test.ts
@@ -1,6 +1,17 @@
 import { z } from 'zod/v4';
-import { betaZodOutputFormat } from '../../src/helpers/beta/zod';
+import { betaZodOutputFormat, betaZodTool } from '../../src/helpers/beta/zod';
 import { zodOutputFormat } from '../../src/helpers/zod';
+
+// Mimic the shape of a zod v3 schema: `_def.typeName` is set, `_zod` is absent.
+// We only need enough surface for the type system; runtime never reaches `safeParse`
+// because the v4 assertion short-circuits first.
+function fakeZodV3Schema(): any {
+  return {
+    _def: { typeName: 'ZodObject' },
+    safeParse: () => ({ success: true, data: {} }),
+    parse: (v: unknown) => v,
+  };
+}
 
 describe('beta zod helpers', () => {
   describe('betaZodOutputFormat', () => {
@@ -502,6 +513,28 @@ describe('GA zod helpers', () => {
 
       expect(() => format.parse('invalid json')).toThrow();
       expect(() => format.parse('{"incomplete": ')).toThrow();
+    });
+  });
+
+  describe('zod v3 schema rejection', () => {
+    it('zodOutputFormat throws a clear error when given a v3-shaped schema', () => {
+      expect(() => zodOutputFormat(fakeZodV3Schema())).toThrow(/zod v4 schema/);
+      expect(() => zodOutputFormat(fakeZodV3Schema())).toThrow(/zod\/v4/);
+    });
+
+    it('betaZodOutputFormat throws a clear error when given a v3-shaped schema', () => {
+      expect(() => betaZodOutputFormat(fakeZodV3Schema())).toThrow(/zod v4 schema/);
+    });
+
+    it('betaZodTool throws a clear error when given a v3-shaped input schema', () => {
+      expect(() =>
+        betaZodTool({
+          name: 'noop',
+          description: 'noop',
+          inputSchema: fakeZodV3Schema(),
+          run: async () => 'ok',
+        }),
+      ).toThrow(/zod v4 schema/);
     });
   });
 });


### PR DESCRIPTION
The zod helpers all call `z.toJSONSchema` imported from `zod/v4`, but the package's peerDeps say `zod ^3.25.0 || ^4.0.0` is supported. When someone running against zod 3.x does `import { z } from 'zod'` and passes that schema into `zodOutputFormat`/`betaZodOutputFormat`/`betaZodTool`, the call dies inside the zod v4 internals with a confusing `TypeError: Cannot read properties of undefined (reading 'def')`. Repro from #1035 is a few lines:

```ts
import { zodOutputFormat } from '@anthropic-ai/sdk/helpers/zod';
import zod3 from 'zod';
zodOutputFormat(zod3.object({ foo: zod3.string() })); // throws TypeError
```

I traced this to the shape difference: zod v4 schemas always have a `_zod` property (the new internal namespace), zod v3 schemas don't. `z.toJSONSchema` reaches into `_zod.def` immediately, which is where the `undefined`-deref comes from. The peerDeps wording is honest in spirit because zod 3.25+ ships a `zod/v4` subpath as a backport, so a v3-installed project can import `zod/v4` and get a v4-shaped schema. The user just has to know that's the contract.

So this PR doesn't try to make v3 schemas work (that'd want a different JSON Schema converter and a new dep). It just adds a `src/lib/check-zod-version.ts` helper that detects the v3 shape and throws an `AnthropicError` pointing at the two unblock paths. Wired into the three callsites in `src/helpers/zod.ts` and `src/helpers/beta/zod.ts`. Tests cover all three functions with a v3-shaped mock so we can exercise the detection without juggling two zod installs in dev.

Closes #1035

Test plan:
- [x] `yarn jest tests/helpers/zod.test.ts` passes (23/23, 20 existing + 3 new v3-rejection cases)
- [x] Confirmed against a real `zod@3.25.76` schema in a scratch project that the new error message fires instead of the `TypeError`
- [x] `yarn lint` clean on the touched files
