### PR TITLE
perf(streams): buffer streamed text deltas

### DIFF
--- a/src/lib/BetaMessageStream.ts
+++ b/src/lib/BetaMessageStream.ts
@@ -44,11 +44,49 @@ type MessageStreamEventListeners<Event extends keyof MessageStreamEvents> = {
 }[];
 
 const JSON_BUF_PROPERTY = '__json_buf';
+const TEXT_CHUNKS_PROPERTY = '__text_chunks';
 
 export type TracksToolInput = BetaToolUseBlock | BetaServerToolUseBlock | BetaMCPToolUseBlock;
 
 function tracksToolInput(content: BetaContentBlock): content is TracksToolInput {
   return content.type === 'tool_use' || content.type === 'server_tool_use' || content.type === 'mcp_tool_use';
+}
+
+type BetaTextBlockWithChunks = BetaTextBlock & { [TEXT_CHUNKS_PROPERTY]?: string[] };
+
+function getTextChunks(content: BetaTextBlock): string[] {
+  const contentWithChunks = content as BetaTextBlockWithChunks;
+  let chunks = contentWithChunks[TEXT_CHUNKS_PROPERTY];
+  if (!chunks) {
+    chunks = content.text ? [content.text] : [];
+    Object.defineProperty(contentWithChunks, TEXT_CHUNKS_PROPERTY, {
+      value: chunks,
+      enumerable: false,
+      writable: true,
+    });
+  }
+  return chunks;
+}
+
+function appendTextDelta(content: BetaTextBlock, text: string): BetaTextBlock {
+  getTextChunks(content).push(text);
+  return content;
+}
+
+function materializeTextBlock<T extends BetaTextBlock>(content: T): T {
+  const chunks = (content as BetaTextBlockWithChunks)[TEXT_CHUNKS_PROPERTY];
+  if (!chunks) return content;
+
+  const text = chunks.join('');
+  if (content.text === text) return content;
+
+  const nextContent = { ...content, text };
+  Object.defineProperty(nextContent, TEXT_CHUNKS_PROPERTY, {
+    value: chunks,
+    enumerable: false,
+    writable: true,
+  });
+  return nextContent;
 }
 
 export class BetaMessageStream<ParsedT = null> implements AsyncIterable<BetaMessageStreamEvent> {
@@ -316,7 +354,9 @@ export class BetaMessageStream<ParsedT = null> implements AsyncIterable<BetaMess
   }
 
   get currentMessage(): BetaMessage | undefined {
-    return this.#currentMessageSnapshot;
+    return this.#currentMessageSnapshot ?
+        this.#materializeMessageText(this.#currentMessageSnapshot)
+      : undefined;
   }
 
   #getFinalMessage(): ParsedBetaMessage<ParsedT> {
@@ -436,6 +476,28 @@ export class BetaMessageStream<ParsedT = null> implements AsyncIterable<BetaMess
     }
   }
 
+  #hasListeners<Event extends keyof MessageStreamEvents>(event: Event): boolean {
+    return (this.#listeners[event]?.length ?? 0) > 0;
+  }
+
+  #materializeTextContent(message: BetaMessage, index: number): BetaTextBlock | undefined {
+    const content = message.content.at(index);
+    if (content?.type !== 'text') return undefined;
+
+    const materializedContent = materializeTextBlock(content);
+    if (materializedContent !== content) {
+      message.content[index] = materializedContent;
+    }
+    return materializedContent;
+  }
+
+  #materializeMessageText(message: BetaMessage): BetaMessage {
+    for (let index = 0; index < message.content.length; index++) {
+      this.#materializeTextContent(message, index);
+    }
+    return message;
+  }
+
   #beginRequest() {
     if (this.ended) return;
     this.#currentMessageSnapshot = undefined;
@@ -443,15 +505,23 @@ export class BetaMessageStream<ParsedT = null> implements AsyncIterable<BetaMess
   #addStreamEvent(event: BetaMessageStreamEvent) {
     if (this.ended) return;
     const messageSnapshot = this.#accumulateMessage(event);
+    if (
+      this.#hasListeners('streamEvent') &&
+      event.type === 'content_block_delta' &&
+      event.delta.type === 'text_delta'
+    ) {
+      this.#materializeTextContent(messageSnapshot, event.index);
+    }
     this._emit('streamEvent', event, messageSnapshot);
 
     switch (event.type) {
       case 'content_block_delta': {
-        const content = messageSnapshot.content.at(-1)!;
+        const content = messageSnapshot.content.at(event.index)!;
         switch (event.delta.type) {
           case 'text_delta': {
-            if (content.type === 'text') {
-              this._emit('text', event.delta.text, content.text || '');
+            if (content.type === 'text' && this.#hasListeners('text')) {
+              const textSnapshot = this.#materializeTextContent(messageSnapshot, event.index)?.text ?? '';
+              this._emit('text', event.delta.text, textSnapshot);
             }
             break;
           }
@@ -491,6 +561,7 @@ export class BetaMessageStream<ParsedT = null> implements AsyncIterable<BetaMess
         break;
       }
       case 'message_stop': {
+        this.#materializeMessageText(messageSnapshot);
         this._addMessageParam(messageSnapshot);
         this._addMessage(
           maybeParseBetaMessage(messageSnapshot, this.#params, { logger: this.#logger }),
@@ -499,7 +570,8 @@ export class BetaMessageStream<ParsedT = null> implements AsyncIterable<BetaMess
         break;
       }
       case 'content_block_stop': {
-        this._emit('contentBlock', messageSnapshot.content.at(-1)!);
+        this.#materializeTextContent(messageSnapshot, event.index);
+        this._emit('contentBlock', messageSnapshot.content.at(event.index)!);
         break;
       }
       case 'message_start': {
@@ -519,6 +591,7 @@ export class BetaMessageStream<ParsedT = null> implements AsyncIterable<BetaMess
     if (!snapshot) {
       throw new AnthropicError(`request ended without sending any chunks`);
     }
+    this.#materializeMessageText(snapshot);
     this.#currentMessageSnapshot = undefined;
     return maybeParseBetaMessage(snapshot, this.#params, { logger: this.#logger });
   }
@@ -611,10 +684,7 @@ export class BetaMessageStream<ParsedT = null> implements AsyncIterable<BetaMess
         switch (event.delta.type) {
           case 'text_delta': {
             if (snapshotContent?.type === 'text') {
-              snapshot.content[event.index] = {
-                ...snapshotContent,
-                text: (snapshotContent.text || '') + event.delta.text,
-              };
+              snapshot.content[event.index] = appendTextDelta(snapshotContent, event.delta.text);
             }
             break;
           }
@@ -689,6 +759,7 @@ export class BetaMessageStream<ParsedT = null> implements AsyncIterable<BetaMess
         return snapshot;
       }
       case 'content_block_stop':
+        this.#materializeTextContent(snapshot, event.index);
         return snapshot;
     }
   }

--- a/src/lib/MessageStream.ts
+++ b/src/lib/MessageStream.ts
@@ -41,11 +41,49 @@ type MessageStreamEventListeners<ParsedT, Event extends keyof MessageStreamEvent
 }[];
 
 const JSON_BUF_PROPERTY = '__json_buf';
+const TEXT_CHUNKS_PROPERTY = '__text_chunks';
 
 export type TracksToolInput = ToolUseBlock | ServerToolUseBlock;
 
 function tracksToolInput(content: ContentBlock): content is TracksToolInput {
   return content.type === 'tool_use' || content.type === 'server_tool_use';
+}
+
+type TextBlockWithChunks = TextBlock & { [TEXT_CHUNKS_PROPERTY]?: string[] };
+
+function getTextChunks(content: TextBlock): string[] {
+  const contentWithChunks = content as TextBlockWithChunks;
+  let chunks = contentWithChunks[TEXT_CHUNKS_PROPERTY];
+  if (!chunks) {
+    chunks = content.text ? [content.text] : [];
+    Object.defineProperty(contentWithChunks, TEXT_CHUNKS_PROPERTY, {
+      value: chunks,
+      enumerable: false,
+      writable: true,
+    });
+  }
+  return chunks;
+}
+
+function appendTextDelta(content: TextBlock, text: string): TextBlock {
+  getTextChunks(content).push(text);
+  return content;
+}
+
+function materializeTextBlock<T extends TextBlock>(content: T): T {
+  const chunks = (content as TextBlockWithChunks)[TEXT_CHUNKS_PROPERTY];
+  if (!chunks) return content;
+
+  const text = chunks.join('');
+  if (content.text === text) return content;
+
+  const nextContent = { ...content, text };
+  Object.defineProperty(nextContent, TEXT_CHUNKS_PROPERTY, {
+    value: chunks,
+    enumerable: false,
+    writable: true,
+  });
+  return nextContent;
 }
 
 export class MessageStream<ParsedT = null> implements AsyncIterable<MessageStreamEvent> {
@@ -324,7 +362,9 @@ export class MessageStream<ParsedT = null> implements AsyncIterable<MessageStrea
   }
 
   get currentMessage(): Message | undefined {
-    return this.#currentMessageSnapshot;
+    return this.#currentMessageSnapshot ?
+        this.#materializeMessageText(this.#currentMessageSnapshot)
+      : undefined;
   }
 
   #getFinalMessage(): ParsedMessage<ParsedT> {
@@ -444,6 +484,28 @@ export class MessageStream<ParsedT = null> implements AsyncIterable<MessageStrea
     }
   }
 
+  #hasListeners<Event extends keyof MessageStreamEvents<ParsedT>>(event: Event): boolean {
+    return (this.#listeners[event]?.length ?? 0) > 0;
+  }
+
+  #materializeTextContent(message: Message, index: number): TextBlock | undefined {
+    const content = message.content.at(index);
+    if (content?.type !== 'text') return undefined;
+
+    const materializedContent = materializeTextBlock(content);
+    if (materializedContent !== content) {
+      message.content[index] = materializedContent;
+    }
+    return materializedContent;
+  }
+
+  #materializeMessageText(message: Message): Message {
+    for (let index = 0; index < message.content.length; index++) {
+      this.#materializeTextContent(message, index);
+    }
+    return message;
+  }
+
   #beginRequest() {
     if (this.ended) return;
     this.#currentMessageSnapshot = undefined;
@@ -451,15 +513,23 @@ export class MessageStream<ParsedT = null> implements AsyncIterable<MessageStrea
   #addStreamEvent(event: MessageStreamEvent) {
     if (this.ended) return;
     const messageSnapshot = this.#accumulateMessage(event);
+    if (
+      this.#hasListeners('streamEvent') &&
+      event.type === 'content_block_delta' &&
+      event.delta.type === 'text_delta'
+    ) {
+      this.#materializeTextContent(messageSnapshot, event.index);
+    }
     this._emit('streamEvent', event, messageSnapshot);
 
     switch (event.type) {
       case 'content_block_delta': {
-        const content = messageSnapshot.content.at(-1)!;
+        const content = messageSnapshot.content.at(event.index)!;
         switch (event.delta.type) {
           case 'text_delta': {
-            if (content.type === 'text') {
-              this._emit('text', event.delta.text, content.text || '');
+            if (content.type === 'text' && this.#hasListeners('text')) {
+              const textSnapshot = this.#materializeTextContent(messageSnapshot, event.index)?.text ?? '';
+              this._emit('text', event.delta.text, textSnapshot);
             }
             break;
           }
@@ -493,12 +563,14 @@ export class MessageStream<ParsedT = null> implements AsyncIterable<MessageStrea
         break;
       }
       case 'message_stop': {
+        this.#materializeMessageText(messageSnapshot);
         this._addMessageParam(messageSnapshot);
         this._addMessage(maybeParseMessage(messageSnapshot, this.#params, { logger: this.#logger }), true);
         break;
       }
       case 'content_block_stop': {
-        this._emit('contentBlock', messageSnapshot.content.at(-1)!);
+        this.#materializeTextContent(messageSnapshot, event.index);
+        this._emit('contentBlock', messageSnapshot.content.at(event.index)!);
         break;
       }
       case 'message_start': {
@@ -518,6 +590,7 @@ export class MessageStream<ParsedT = null> implements AsyncIterable<MessageStrea
     if (!snapshot) {
       throw new AnthropicError(`request ended without sending any chunks`);
     }
+    this.#materializeMessageText(snapshot);
     this.#currentMessageSnapshot = undefined;
     return maybeParseMessage(snapshot, this.#params, { logger: this.#logger });
   }
@@ -605,10 +678,7 @@ export class MessageStream<ParsedT = null> implements AsyncIterable<MessageStrea
         switch (event.delta.type) {
           case 'text_delta': {
             if (snapshotContent?.type === 'text') {
-              snapshot.content[event.index] = {
-                ...snapshotContent,
-                text: (snapshotContent.text || '') + event.delta.text,
-              };
+              snapshot.content[event.index] = appendTextDelta(snapshotContent, event.delta.text);
             }
             break;
           }
@@ -668,6 +738,7 @@ export class MessageStream<ParsedT = null> implements AsyncIterable<MessageStrea
         return snapshot;
       }
       case 'content_block_stop':
+        this.#materializeTextContent(snapshot, event.index);
         return snapshot;
     }
   }

--- a/tests/api-resources/MessageStream.test.ts
+++ b/tests/api-resources/MessageStream.test.ts
@@ -81,6 +81,37 @@ function assertToolUseResponse(events: MessageStreamEvent[], message: Message) {
   expect(message).toMatchObject(EXPECTED_TOOL_USE_MESSAGE);
 }
 
+function buildTextStreamEvents(chunks: string[]): unknown[] {
+  return [
+    {
+      type: 'message_start',
+      message: {
+        id: 'msg_text_chunks',
+        type: 'message',
+        role: 'assistant',
+        content: [],
+        model: 'claude-opus-4-20250514',
+        stop_reason: null,
+        stop_sequence: null,
+        usage: { input_tokens: 1, output_tokens: 1 },
+      },
+    },
+    { type: 'content_block_start', index: 0, content_block: { type: 'text', text: '' } },
+    ...chunks.map((text) => ({
+      type: 'content_block_delta' as const,
+      index: 0,
+      delta: { type: 'text_delta' as const, text },
+    })),
+    { type: 'content_block_stop', index: 0 },
+    {
+      type: 'message_delta',
+      delta: { stop_reason: 'end_turn', stop_sequence: null },
+      usage: { output_tokens: chunks.length },
+    },
+    { type: 'message_stop' },
+  ];
+}
+
 describe('MessageStream class', () => {
   it('aborts on break', async () => {
     const { fetch, handleStreamEvents } = mockFetch();
@@ -196,6 +227,59 @@ describe('MessageStream class', () => {
 
     assertBasicResponse(events, finalMessage);
     expect(finalText).toBe('Hello there!');
+  });
+
+  it('accumulates long text streams into the final message', async () => {
+    const { fetch, handleStreamEvents } = mockFetch();
+    const anthropic = new Anthropic({ apiKey: '...', fetch });
+
+    const chunks = Array.from({ length: 500 }, (_, index) => `${index},`);
+    handleStreamEvents(buildTextStreamEvents(chunks));
+
+    const stream = anthropic.messages.stream({
+      max_tokens: 1024,
+      model: 'claude-opus-4-20250514',
+      messages: [{ role: 'user', content: 'Stream text chunks.' }],
+    });
+
+    for await (const _event of stream) {
+      // Consume the stream.
+    }
+
+    const finalMessage = await stream.finalMessage();
+    expect(finalMessage.content).toEqual([{ type: 'text', text: chunks.join('') }]);
+  });
+
+  it('keeps text snapshots current for text and streamEvent listeners', async () => {
+    const { fetch, handleStreamEvents } = mockFetch();
+    const anthropic = new Anthropic({ apiKey: '...', fetch });
+
+    handleStreamEvents(buildTextStreamEvents(['Hel', 'lo']));
+
+    const stream = anthropic.messages.stream({
+      max_tokens: 1024,
+      model: 'claude-opus-4-20250514',
+      messages: [{ role: 'user', content: 'Say hello.' }],
+    });
+
+    const textSnapshots: string[] = [];
+    const streamEventTextSnapshots: string[] = [];
+    stream.on('text', (_delta, snapshot) => {
+      textSnapshots.push(snapshot);
+    });
+    stream.on('streamEvent', (event, snapshot) => {
+      if (event.type === 'content_block_delta' && event.delta.type === 'text_delta') {
+        const content = snapshot.content[0];
+        if (content?.type === 'text') streamEventTextSnapshots.push(content.text);
+      }
+    });
+
+    for await (const _event of stream) {
+      // Consume the stream.
+    }
+
+    expect(textSnapshots).toEqual(['Hel', 'Hello']);
+    expect(streamEventTextSnapshots).toEqual(['Hel', 'Hello']);
   });
 
   it('handles tool use response fixture', async () => {


### PR DESCRIPTION
## Summary
- buffer streamed text deltas on message snapshots and materialize the joined text only when snapshots are observed or finalized
- keep existing text and streamEvent listener snapshots current by materializing when those listeners are present
- apply the same accumulator behavior to beta message streams
- add regression coverage for long text streams and listener snapshots

Fixes #995

## Test plan
- `./node_modules/.bin/jest tests/api-resources/MessageStream.test.ts --runInBand`
- `./node_modules/.bin/jest tests/api-resources/BetaMessageStream.test.ts --runInBand`
- `./node_modules/typescript/bin/tsc --pretty false`
- `./node_modules/.bin/prettier --check src/lib/MessageStream.ts src/lib/BetaMessageStream.ts tests/api-resources/MessageStream.test.ts`
- `./node_modules/.bin/eslint src/lib/MessageStream.ts src/lib/BetaMessageStream.ts tests/api-resources/MessageStream.test.ts`