### PR TITLE
fix(memory): reject malformed memories paths

### DIFF
--- a/src/tools/memory/node.ts
+++ b/src/tools/memory/node.ts
@@ -140,8 +140,8 @@ export class BetaLocalFilesystemMemoryTool implements MemoryToolHandlers {
   }
 
   private async validatePath(memoryPath: string): Promise<string> {
-    if (!memoryPath.startsWith('/memories')) {
-      throw new Error(`Path must start with /memories, got: ${memoryPath}`);
+    if (memoryPath !== '/memories' && !memoryPath.startsWith('/memories/')) {
+      throw new Error(`Path must be /memories or start with /memories/, got: ${memoryPath}`);
     }
 
     const relativePath = memoryPath.slice('/memories'.length).replace(/^\//, '');

--- a/tests/lib/tools/BetaLocalFilesystemMemoryTool.test.ts
+++ b/tests/lib/tools/BetaLocalFilesystemMemoryTool.test.ts
@@ -496,7 +496,20 @@ describe('BetaLocalFilesystemMemoryTool', () => {
           file_text: 'Invalid',
           path: '/invalid/path.txt',
         }),
-      ).rejects.toThrow('Path must start with /memories');
+      ).rejects.toThrow('Path must be /memories or start with /memories/');
+    });
+
+    it('should reject paths that only share the /memories prefix', async () => {
+      await expect(
+        tool.create({
+          command: 'create',
+          file_text: 'Invalid',
+          path: '/memories_backup/file.txt',
+        }),
+      ).rejects.toThrow('Path must be /memories or start with /memories/');
+
+      const dirSnapshot = await getDirectorySnapshot(tempDir);
+      expect(dirSnapshot).toEqual({});
     });
 
     it('should reject paths trying to escape /memories', async () => {


### PR DESCRIPTION
## Summary

- require local filesystem memory paths to be exactly `/memories` or start with `/memories/`
- reject prefix-sharing paths such as `/memories_backup/file.txt` instead of silently remapping them under the memory root
- add regression coverage that the malformed path fails and does not create files

## Context

A prior upstream hardening fixed resolved filesystem path boundaries. This patch closes the remaining user-input path boundary: malformed tool paths that merely share the `/memories` string prefix should not be accepted as memory paths.

## Validation

- `git diff --check` -> passed
- `./node_modules/.bin/jest tests/lib/tools/BetaLocalFilesystemMemoryTool.test.ts --runInBand` -> 38 passed
- `./node_modules/.bin/prettier --check src/tools/memory/node.ts tests/lib/tools/BetaLocalFilesystemMemoryTool.test.ts` -> passed
- `./node_modules/.bin/eslint src/tools/memory/node.ts tests/lib/tools/BetaLocalFilesystemMemoryTool.test.ts` -> passed
- `./node_modules/typescript/bin/tsc --noEmit` -> passed