### PR TITLE
fix(stream): preserve cache creation usage deltas

### DIFF
--- a/src/lib/BetaMessageStream.ts
+++ b/src/lib/BetaMessageStream.ts
@@ -589,6 +589,10 @@ export class BetaMessageStream<ParsedT = null> implements AsyncIterable<BetaMess
           snapshot.usage.cache_creation_input_tokens = event.usage.cache_creation_input_tokens;
         }
 
+        if (event.usage.cache_creation != null) {
+          snapshot.usage.cache_creation = event.usage.cache_creation;
+        }
+
         if (event.usage.cache_read_input_tokens != null) {
           snapshot.usage.cache_read_input_tokens = event.usage.cache_read_input_tokens;
         }

--- a/src/lib/MessageStream.ts
+++ b/src/lib/MessageStream.ts
@@ -587,6 +587,10 @@ export class MessageStream<ParsedT = null> implements AsyncIterable<MessageStrea
           snapshot.usage.cache_creation_input_tokens = event.usage.cache_creation_input_tokens;
         }
 
+        if (event.usage.cache_creation != null) {
+          snapshot.usage.cache_creation = event.usage.cache_creation;
+        }
+
         if (event.usage.cache_read_input_tokens != null) {
           snapshot.usage.cache_read_input_tokens = event.usage.cache_read_input_tokens;
         }

--- a/src/resources/beta/messages/messages.ts
+++ b/src/resources/beta/messages/messages.ts
@@ -1911,6 +1911,11 @@ export interface BetaMessage {
 
 export interface BetaMessageDeltaUsage {
   /**
+   * Breakdown of cached tokens by TTL
+   */
+  cache_creation?: BetaCacheCreation | null;
+
+  /**
    * The cumulative number of input tokens used to create the cache entry.
    */
   cache_creation_input_tokens: number | null;

--- a/src/resources/messages/messages.ts
+++ b/src/resources/messages/messages.ts
@@ -1107,6 +1107,11 @@ export type MessageCountTokensTool =
 
 export interface MessageDeltaUsage {
   /**
+   * Breakdown of cached tokens by TTL
+   */
+  cache_creation?: CacheCreation | null;
+
+  /**
    * The cumulative number of input tokens used to create the cache entry.
    */
   cache_creation_input_tokens: number | null;

--- a/tests/api-resources/BetaMessageStream.test.ts
+++ b/tests/api-resources/BetaMessageStream.test.ts
@@ -331,6 +331,88 @@ describe('BetaMessageStream class', () => {
     expect(finalText).toBe("I'll check the current weather in Paris for you.");
   });
 
+  it('preserves cache creation TTL usage from message deltas', async () => {
+    const { fetch, handleStreamEvents } = mockFetch();
+
+    const anthropic = new Anthropic({
+      apiKey: 'test-key',
+      fetch,
+      defaultHeaders: {
+        'anthropic-beta': 'fine-grained-tool-streaming-2025-05-14',
+      },
+    });
+
+    const streamEvents: BetaRawMessageStreamEvent[] = [
+      {
+        type: 'message_start',
+        message: {
+          id: 'msg_cache_usage',
+          container: null,
+          content: [],
+          context_management: null,
+          diagnostics: null,
+          model: 'claude-sonnet-4-5',
+          role: 'assistant',
+          stop_details: null,
+          stop_reason: null,
+          stop_sequence: null,
+          type: 'message',
+          usage: {
+            cache_creation: null,
+            cache_creation_input_tokens: 0,
+            cache_read_input_tokens: 0,
+            inference_geo: null,
+            input_tokens: 10,
+            iterations: null,
+            output_tokens: 0,
+            server_tool_use: null,
+            service_tier: 'standard',
+            speed: 'standard',
+          },
+        },
+      },
+      {
+        type: 'message_delta',
+        context_management: null,
+        delta: {
+          container: null,
+          stop_details: null,
+          stop_reason: 'end_turn',
+          stop_sequence: null,
+        },
+        usage: {
+          cache_creation: {
+            ephemeral_1h_input_tokens: 100,
+            ephemeral_5m_input_tokens: 456,
+          },
+          cache_creation_input_tokens: 556,
+          cache_read_input_tokens: 0,
+          input_tokens: 566,
+          iterations: null,
+          output_tokens: 1,
+          server_tool_use: null,
+        },
+      },
+      { type: 'message_stop' },
+    ];
+    handleStreamEvents(streamEvents);
+
+    const stream = anthropic.beta.messages.stream({
+      max_tokens: 1024,
+      model: 'claude-sonnet-4-5',
+      messages: [{ role: 'user', content: 'Say hello there!' }],
+    });
+
+    await stream.done();
+    const finalMessage = await stream.finalMessage();
+
+    expect(finalMessage.usage.cache_creation).toEqual({
+      ephemeral_1h_input_tokens: 100,
+      ephemeral_5m_input_tokens: 456,
+    });
+    expect(finalMessage.usage.cache_creation_input_tokens).toBe(556);
+  });
+
   it('aborts on break', async () => {
     const { fetch, handleStreamEvents } = mockFetch();
 

--- a/tests/api-resources/MessageStream.test.ts
+++ b/tests/api-resources/MessageStream.test.ts
@@ -226,6 +226,71 @@ describe('MessageStream class', () => {
     expect(finalText).toBe("I'll check the current weather in Paris for you.");
   });
 
+  it('preserves cache creation TTL usage from message deltas', async () => {
+    const { fetch, handleStreamEvents } = mockFetch();
+
+    const anthropic = new Anthropic({ apiKey: '...', fetch });
+
+    const streamEvents: MessageStreamEvent[] = [
+      {
+        type: 'message_start',
+        message: {
+          id: 'msg_cache_usage',
+          container: null,
+          content: [],
+          model: 'claude-sonnet-4-5',
+          role: 'assistant',
+          stop_details: null,
+          stop_reason: null,
+          stop_sequence: null,
+          type: 'message',
+          usage: {
+            cache_creation: null,
+            cache_creation_input_tokens: 0,
+            cache_read_input_tokens: 0,
+            inference_geo: null,
+            input_tokens: 10,
+            output_tokens: 0,
+            server_tool_use: null,
+            service_tier: 'standard',
+          },
+        },
+      },
+      {
+        type: 'message_delta',
+        delta: { container: null, stop_details: null, stop_reason: 'end_turn', stop_sequence: null },
+        usage: {
+          cache_creation: {
+            ephemeral_1h_input_tokens: 100,
+            ephemeral_5m_input_tokens: 456,
+          },
+          cache_creation_input_tokens: 556,
+          cache_read_input_tokens: 0,
+          input_tokens: 566,
+          output_tokens: 1,
+          server_tool_use: null,
+        },
+      },
+      { type: 'message_stop' },
+    ];
+    handleStreamEvents(streamEvents);
+
+    const stream = anthropic.messages.stream({
+      max_tokens: 1024,
+      model: 'claude-sonnet-4-5',
+      messages: [{ role: 'user', content: 'Say hello there!' }],
+    });
+
+    await stream.done();
+    const finalMessage = await stream.finalMessage();
+
+    expect(finalMessage.usage.cache_creation).toEqual({
+      ephemeral_1h_input_tokens: 100,
+      ephemeral_5m_input_tokens: 456,
+    });
+    expect(finalMessage.usage.cache_creation_input_tokens).toBe(556);
+  });
+
   it('does not throw unhandled rejection with withResponse()', async () => {
     const { fetch, handleRequest } = mockFetch();
     const anthropic = new Anthropic({


### PR DESCRIPTION
## Summary

- expose `cache_creation` on stable and beta message delta usage types
- preserve cache creation TTL breakdowns when accumulating streamed message deltas into the final message snapshot
- add stable and beta mock-stream regression coverage for `ephemeral_5m_input_tokens` and `ephemeral_1h_input_tokens`

Fixes #793.

## Validation

- `./node_modules/.bin/jest tests/api-resources/MessageStream.test.ts tests/api-resources/BetaMessageStream.test.ts --runInBand --testNamePattern="cache creation TTL"`
- `./node_modules/.bin/jest tests/api-resources/MessageStream.test.ts tests/api-resources/BetaMessageStream.test.ts --runInBand`
- `./node_modules/.bin/prettier --check tests/api-resources/BetaMessageStream.test.ts tests/api-resources/MessageStream.test.ts src/lib/BetaMessageStream.ts src/lib/MessageStream.ts src/resources/beta/messages/messages.ts src/resources/messages/messages.ts`
- `./node_modules/.bin/eslint src/resources/messages/messages.ts src/resources/beta/messages/messages.ts src/lib/MessageStream.ts src/lib/BetaMessageStream.ts tests/api-resources/MessageStream.test.ts tests/api-resources/BetaMessageStream.test.ts`
- `./node_modules/typescript/bin/tsc --noEmit`
- `./scripts/build`
- `git diff --check`