### PR TITLE
feat(bedrock-sdk): expose `.models` resource for parity with the main client (#704)

### DIFF
--- a/packages/bedrock-sdk/src/client.ts
+++ b/packages/bedrock-sdk/src/client.ts
@@ -133,6 +133,16 @@ export class AnthropicBedrock extends BaseAnthropic {
 
   messages: MessagesResource = makeMessagesResource(this);
   completions: Resources.Completions = new Resources.Completions(this);
+  /**
+   * Models listing and retrieval.
+   *
+   * Routes to `/v1/models` / `/v1/models/{model_id}` against the configured
+   * Bedrock base URL. Whether AWS Bedrock honors this path is up to AWS;
+   * adding the property keeps the `AnthropicBedrock` client's surface in
+   * parity with the main `Anthropic` client (#704), which is useful for
+   * code that types against a unified Anthropic-style interface.
+   */
+  models: Resources.Models = new Resources.Models(this);
   beta: BetaResource = makeBetaResource(this);
 
   protected override validateHeaders() {

--- a/packages/bedrock-sdk/tests/client.test.ts
+++ b/packages/bedrock-sdk/tests/client.test.ts
@@ -260,3 +260,59 @@ describe('AnthropicBedrock constructor deprecation warnings', () => {
     );
   });
 });
+
+describe('Resource surface parity with the main Anthropic client (#704)', () => {
+  test('exposes a `models` resource', () => {
+    const client = new AnthropicBedrock({
+      awsRegion: 'us-east-1',
+      awsAccessKey: 'access-key',
+      awsSecretKey: 'secret-key',
+    });
+
+    expect(client.models).toBeDefined();
+    // sanity-check the methods callers rely on for parity with the main SDK
+    expect(typeof client.models.list).toBe('function');
+    expect(typeof client.models.retrieve).toBe('function');
+  });
+
+  test('does not put `/v1/models` into the AWS path-rewrite set', async () => {
+    // The AWS-style rewrite only fires for POSTs to MODEL_ENDPOINTS
+    // (/v1/complete, /v1/messages, /v1/messages?beta=true). A GET to
+    // /v1/models must pass through unchanged so it actually targets the
+    // Anthropic Models API path (whether AWS Bedrock honors it at runtime
+    // is up to AWS — see #704). This test pins that we did not accidentally
+    // route models through the InvokeModel rewrite.
+    const fetchMock = jest.fn().mockImplementation(() =>
+      Promise.resolve({
+        ok: true,
+        status: 200,
+        statusText: 'OK',
+        headers: new Headers({ 'content-type': 'application/json' }),
+        json: () => Promise.resolve({ data: [], has_more: false, first_id: null, last_id: null }),
+        text: () =>
+          Promise.resolve('{"data":[],"has_more":false,"first_id":null,"last_id":null}'),
+      }),
+    );
+    const previousFetch = global.fetch;
+    global.fetch = fetchMock as any;
+
+    try {
+      const client = new AnthropicBedrock({
+        awsRegion: 'us-east-1',
+        awsAccessKey: 'access-key',
+        awsSecretKey: 'secret-key',
+        baseURL: 'http://localhost:4010',
+      });
+
+      await client.models.list();
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+
+      const requestedUrl = (fetchMock.mock.calls[0]?.[0] ?? '').toString();
+      // Path passed through unchanged (no /model/<id>/invoke rewrite).
+      expect(requestedUrl).toMatch(/\/v1\/models($|\?)/);
+      expect(requestedUrl).not.toMatch(/\/model\//);
+    } finally {
+      global.fetch = previousFetch;
+    }
+  });
+});


### PR DESCRIPTION
Closes #704.

## Why

The Bedrock SDK extends `BaseAnthropic` (not the resourceful `Anthropic` class), so it never inherited the `.models` resource that the main client exposes. Issue #704 asks for parity so callers can type against a unified Anthropic-style interface across the main / Vertex / Bedrock variants.

## What

In `packages/bedrock-sdk/src/client.ts`, add the property alongside the existing `messages` / `completions` / `beta` declarations:

```ts
models: Resources.Models = new Resources.Models(this);
```

`/v1/models` is intentionally **not** added to `MODEL_ENDPOINTS`. That set only matches POSTs that need the AWS-style `/model/<id>/invoke` rewrite. A GET to `/v1/models` (or `/v1/models/{id}`) passes through `buildRequest` unchanged, so the request actually targets the Anthropic Models path against the configured Bedrock base URL.

## Honest caveat on runtime behavior

Whether `bedrock-runtime.<region>.amazonaws.com/v1/models` is honored by AWS at runtime is up to AWS. This PR is concerned with **SDK surface parity** so callers can write:

```ts
const models = await client.models.list();
```

against either `Anthropic` or `AnthropicBedrock` and have the call typecheck identically. If maintainers would prefer the foundry-sdk pattern (`override models = undefined` with a doc comment) instead, I'm happy to switch — `bedrock-sdk` extends `BaseAnthropic` so there's no parent property to literally `override`, but the sentinel can be added as a top-level `models: undefined = undefined` field with a clear comment instead. Let me know which direction you'd like.

## Tests

New `describe('Resource surface parity with the main Anthropic client (#704)')` block in `packages/bedrock-sdk/tests/client.test.ts`:

1. **`exposes a 'models' resource`** — constructs `AnthropicBedrock`, asserts `client.models` is defined and exposes both `list` and `retrieve` as functions.
2. **`does not put '/v1/models' into the AWS path-rewrite set`** — mocks global `fetch`, calls `client.models.list()`, asserts the request URL ends in `/v1/models` (no `/model/<id>/invoke` rewrite, confirming the rewrite logic stays scoped to POSTs in `MODEL_ENDPOINTS`).

Local run: **10/10 tests pass** in `packages/bedrock-sdk` (8 pre-existing + 2 new).

## Files changed

- `packages/bedrock-sdk/src/client.ts` (+10 lines): added `models: Resources.Models = new Resources.Models(this)` with JSDoc.
- `packages/bedrock-sdk/tests/client.test.ts` (+56 lines): added the parity describe block with 2 tests.

## Checklist

- [x] Hand-written SDK code only (`src/lib`-style); no codegen edits.
- [x] Linked the originating issue (`Closes #704`).
- [x] Tests added and passing locally.
- [x] Conventional `feat(bedrock-sdk):` title and commit.
- [x] No behavior change to existing paths.