### PR TITLE
docs(streams): remove "the the" duplicate-word typo in MessageStream JSDoc

### DIFF
--- a/src/lib/BetaMessageStream.ts
+++ b/src/lib/BetaMessageStream.ts
@@ -327,7 +327,7 @@ export class BetaMessageStream<ParsedT = null> implements AsyncIterable<BetaMess
   }
 
   /**
-   * @returns a promise that resolves with the the final assistant Message response,
+   * @returns a promise that resolves with the final assistant Message response,
    * or rejects if an error occurred or the stream ended prematurely without producing a Message.
    * If structured outputs were used, this will be a ParsedMessage with a `parsed` field.
    */
@@ -351,7 +351,7 @@ export class BetaMessageStream<ParsedT = null> implements AsyncIterable<BetaMess
   }
 
   /**
-   * @returns a promise that resolves with the the final assistant Message's text response, concatenated
+   * @returns a promise that resolves with the final assistant Message's text response, concatenated
    * together if there are more than one text blocks.
    * Rejects if an error occurred or the stream ended prematurely without producing a Message.
    */

--- a/src/lib/MessageStream.ts
+++ b/src/lib/MessageStream.ts
@@ -335,7 +335,7 @@ export class MessageStream<ParsedT = null> implements AsyncIterable<MessageStrea
   }
 
   /**
-   * @returns a promise that resolves with the the final assistant Message response,
+   * @returns a promise that resolves with the final assistant Message response,
    * or rejects if an error occurred or the stream ended prematurely without producing a Message.
    * If structured outputs were used, this will be a ParsedMessage with a `parsed_output` field.
    */
@@ -359,7 +359,7 @@ export class MessageStream<ParsedT = null> implements AsyncIterable<MessageStrea
   }
 
   /**
-   * @returns a promise that resolves with the the final assistant Message's text response, concatenated
+   * @returns a promise that resolves with the final assistant Message's text response, concatenated
    * together if there are more than one text blocks.
    * Rejects if an error occurred or the stream ended prematurely without producing a Message.
    */


### PR DESCRIPTION
## Summary

Four \`@returns\` JSDoc lines in the hand-written stream helpers share the same duplicated \`the\`:

\`\`\`diff
- * @returns a promise that resolves with the the final assistant Message response,
+ * @returns a promise that resolves with the final assistant Message response,
\`\`\`

\`\`\`diff
- * @returns a promise that resolves with the the final assistant Message's text response, concatenated
+ * @returns a promise that resolves with the final assistant Message's text response, concatenated
\`\`\`

Affected lines:

- \`src/lib/MessageStream.ts:338\` (\`finalMessage\`)
- \`src/lib/MessageStream.ts:362\` (\`finalText\`)
- \`src/lib/BetaMessageStream.ts:330\` (\`finalMessage\`)
- \`src/lib/BetaMessageStream.ts:354\` (\`finalText\`)

Per \`CONTRIBUTING.md\`: *\"The generator will never modify the contents of the \`src/lib/\` and \`examples/\` directories\"* — so these are hand-written and safe to patch directly.

Diff is exactly 4 lines, JSDoc-only — no runtime/type behavior change.

## Novelty

\`gh search prs --repo anthropics/anthropic-sdk-typescript \"the the final\"\` returns no matches. Open PRs touching MessageStream (#997, #954, #943, etc.) are functional fixes to different code; no overlap.