### PR TITLE
fix(partial-json): keep complete trailing numbers in arrays

### DIFF
--- a/src/_vendor/partial-json-parser/parser.ts
+++ b/src/_vendor/partial-json-parser/parser.ts
@@ -187,6 +187,7 @@ const tokenize = (input: string): Token[] => {
           tokens = tokens.slice(0, tokens.length - 1);
           return strip(tokens);
         }
+        break;
       case 'string':
         let tokenBeforeTheLastToken = tokens[tokens.length - 2];
         if (tokenBeforeTheLastToken?.type === 'delimiter') {

--- a/tests/lib/partial-json.test.ts
+++ b/tests/lib/partial-json.test.ts
@@ -51,6 +51,19 @@ describe('partialParse', () => {
     expect(partialParse(`{"foo": 123, "bar": 45.67}`)).toEqual({ foo: 123, bar: 45.67 });
   });
 
+  test('array with a complete trailing number after a comma', () => {
+    expect(partialParse(`{"foo": [1, 2`)).toEqual({ foo: [1, 2] });
+  });
+
+  test('array with multiple complete trailing numbers', () => {
+    expect(partialParse(`{"nums": [10, 20, 3`)).toEqual({ nums: [10, 20, 3] });
+  });
+
+  test('array with an incomplete trailing number', () => {
+    expect(partialParse(`{"foo": [1, 2.`)).toEqual({ foo: [1] });
+    expect(partialParse(`{"foo": [1, -`)).toEqual({ foo: [1] });
+  });
+
   test('JSON string with boolean values', () => {
     expect(partialParse(`{"foo": true, "bar": false}`)).toEqual({ foo: true, bar: false });
   });


### PR DESCRIPTION
## Bug

`partialParse` drops complete numeric array elements while a JSON buffer is still being streamed:

```ts
partialParse('{"foo": [1, 2');        // => { foo: [1] }          (expected { foo: [1, 2] })
partialParse('{"nums": [10, 20, 3');  // => { nums: [10] }        (expected { nums: [10, 20, 3] })
```

It only happens for numbers that come after a `,` or directly after `{`. Numbers in other positions are kept correctly, so the behavior is inconsistent:

```ts
partialParse('{"foo": 123');  // => { foo: 123 }  ✅ (number after `:`)
partialParse('[1');           // => [1]           ✅ (single element)
partialParse('[1, 2');        // => [1]           ❌ (element after `,`)
```

This shows up in real usage via `MessageStream` / `BetaMessageStream`, which call `partialParse` on the accumulated buffer for every `input_json_delta`. When a tool's input contains a numeric array, the in-progress `content[i].input` snapshot loses the most recent elements until the next non-number token arrives, so values appear to flicker/disappear during streaming.

## Root cause

In `strip()`, the `number` case is missing a `break`:

```ts
case 'number':
  let lastCharacterOfLastToken = lastToken.value[lastToken.value.length - 1];
  if (lastCharacterOfLastToken === '.' || lastCharacterOfLastToken === '-') {
    tokens = tokens.slice(0, tokens.length - 1);
    return strip(tokens);
  }
  // falls through to `case 'string'`
case 'string':
  ...
```

When a complete number does **not** end in `.`/`-`, execution falls through into the `string` case, which strips a trailing token if the token before it is a `delimiter` (`,`) or an opening `{`. That logic is meant for possibly-incomplete strings/keys, not for complete numbers, so it removes a valid number. Because `strip()` recurses, a run of trailing numbers gets removed one after another (e.g. `[10, 20, 3` collapses to `[10]`).

The intent of the `number` case is to strip only *incomplete* numbers (those ending in `.` or `-`); a complete number should be kept, exactly as it already is when it appears as an object value or as the sole array element.

## Fix

Add the missing `break` so a complete number is preserved instead of falling through into the string-stripping logic. Incomplete numbers (ending in `.`/`-`) are still stripped as before.

## Testing

Added cases to `tests/lib/partial-json.test.ts` covering complete trailing numbers in arrays (single and multiple) and an incomplete trailing number. The new "complete trailing number" tests fail before the change and pass after it; the incomplete-number test passes both ways. `yarn lint` and the existing partial-json / streaming suites are green.