### PR TITLE
fix(vertex): strip anthropic-beta header from countTokens requests

### DIFF
--- a/packages/vertex-sdk/src/client.ts
+++ b/packages/vertex-sdk/src/client.ts
@@ -192,6 +192,12 @@ export class AnthropicVertex extends BaseAnthropic {
       }
 
       options.path = `/projects/${this.projectId}/locations/${this.region}/publishers/anthropic/models/count-tokens:rawPredict`;
+
+      // Vertex AI's count-tokens endpoint rejects any anthropic-beta value that the
+      // target model backend has not yet rolled out. Strip the header so countTokens
+      // calls always succeed regardless of which beta features are active on the
+      // surrounding messages call. Token counting does not use beta-gated capabilities.
+      options.headers = buildHeaders([options.headers, { 'anthropic-beta': null }]);
     }
 
     return super.buildRequest(options);

--- a/packages/vertex-sdk/tests/client.test.ts
+++ b/packages/vertex-sdk/tests/client.test.ts
@@ -1,6 +1,7 @@
 // File generated from our OpenAPI spec by Stainless. See CONTRIBUTING.md for details.
 
 import { AnthropicVertex } from '../src/client';
+import { FinalRequestOptions } from '../src/internal/request-options';
 
 // Mock GoogleAuth to prevent credential loading during tests
 jest.mock('google-auth-library', () => ({
@@ -86,6 +87,44 @@ describe('AnthropicVertex', () => {
           process.env['CLOUD_ML_REGION'] = originalEnv;
         }
       }
+    });
+  });
+
+  describe('count_tokens beta header stripping', () => {
+    const client = new AnthropicVertex({
+      region: 'us-central1',
+      projectId: 'test-project',
+      accessToken: 'fake-token',
+    });
+
+    test('strips anthropic-beta header from /v1/messages/count_tokens requests', async () => {
+      const { req } = await client.buildRequest({
+        path: '/v1/messages/count_tokens',
+        method: 'post',
+        headers: { 'anthropic-beta': 'some-beta-feature-2025-01-01' },
+        body: { model: 'claude-haiku-4-5', messages: [] },
+      } as FinalRequestOptions);
+      expect(req.headers.has('anthropic-beta')).toBe(false);
+    });
+
+    test('strips anthropic-beta header from /v1/messages/count_tokens?beta=true requests', async () => {
+      const { req } = await client.buildRequest({
+        path: '/v1/messages/count_tokens?beta=true',
+        method: 'post',
+        headers: { 'anthropic-beta': 'effort-2025-11-24' },
+        body: { model: 'claude-haiku-4-5', messages: [] },
+      } as FinalRequestOptions);
+      expect(req.headers.has('anthropic-beta')).toBe(false);
+    });
+
+    test('does not strip anthropic-beta header from regular /v1/messages requests', async () => {
+      const { req } = await client.buildRequest({
+        path: '/v1/messages',
+        method: 'post',
+        headers: { 'anthropic-beta': 'some-beta-feature-2025-01-01' },
+        body: { model: 'claude-haiku-4-5', stream: false, messages: [] },
+      } as FinalRequestOptions);
+      expect(req.headers.get('anthropic-beta')).toBe('some-beta-feature-2025-01-01');
     });
   });
 });


### PR DESCRIPTION
## Summary

Vertex AI's `count-tokens` endpoint rejects `anthropic-beta` header values that the target model backend has not yet rolled out. Model backends on Vertex roll out new beta values on their own schedules — Haiku consistently lags — so passing any recently-introduced beta value (e.g. `effort-2025-11-24`, `structured-outputs-2025-12-15`, `context-1m-2025-08-07`) to a `countTokens` call against the wrong model tier returns HTTP 400 `"Unexpected value(s) \`...\` for the \`anthropic-beta\` header"`. This is the same root cause that has been re-triggering in claude-code#11154 every time a new beta is introduced.

The fix strips `anthropic-beta` from the request headers inside `buildRequest` when the path is the count-tokens path. Token counting does not need any beta-gated capability, so removing the header is safe and structurally prevents the recurrence rather than requiring each new beta to wait for Vertex's Haiku rollout.

Three tests are added to `packages/vertex-sdk/tests/client.test.ts` to verify the new behaviour: that the header is stripped from both the plain and `?beta=true` count-tokens paths, and that it is preserved for normal `/v1/messages` requests.

## Issue

Closes #1016

## Local verification

```
$ cd packages/vertex-sdk && npx jest

PASS tests/client.test.ts
  AnthropicVertex
    baseURL configuration
      ✓ global region uses correct base URL (3 ms)
      ✓ us region uses correct base URL (1 ms)
      ✓ eu region eues correct base URL (1 ms)
      ✓ regional endpoint us-central1 uses correct base URL format (1 ms)
      ✓ regional endpoint europe-west1 uses correct base URL format (1 ms)
      ✓ regional endpoint asia-southeast1 uses correct base URL format
      ✓ explicit baseURL option takes precedence over region
      ✓ throws error when region is not provided (5 ms)
    count_tokens beta header stripping
      ✓ strips anthropic-beta header from /v1/messages/count_tokens requests (6 ms)
      ✓ strips anthropic-beta header from /v1/messages/count_tokens?beta=true requests (1 ms)
      ✓ does not strip anthropic-beta header from regular /v1/messages requests

Test Suites: 1 passed, 1 total
Tests:       11 passed, 11 total
Snapshots:   0 total
Time:        0.298 s

$ cd ../.. && npx eslint packages/vertex-sdk/src/client.ts packages/vertex-sdk/tests/client.test.ts
(no output — clean)
=== LOCAL_TEST_PASSED ===
```

## Risk

The change only affects `AnthropicVertex.buildRequest` for the count-tokens paths — all other paths are untouched. Callers who were setting `anthropic-beta` on a `countTokens` call explicitly (unusual; the header is normally injected by beta message resource classes) will lose that header on Vertex, but that header was already causing their call to 400 on lagging model tiers, so this is strictly an improvement. The main Anthropic API (`AnthropicBedrock`, `Anthropic`) is unaffected.
