### PR TITLE
docs(MIGRATION): replace dead README anchors with canonical URL

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -173,10 +173,11 @@ client.example.list(undefined, { headers: { ... } });
 
 ### Removed `httpAgent` in favor of `fetchOptions`
 
-The `httpAgent` client option has been removed in favor of a [platform-specific `fetchOptions` property](https://github.com/anthropics/anthropic-sdk-typescript#fetch-options).
+The `httpAgent` client option has been removed in favor of a platform-specific `fetchOptions` property.
+See the [TypeScript SDK documentation](https://platform.claude.com/docs/en/api/sdks/typescript) for details.
 This change was made as `httpAgent` relied on `node:http` agents which are not supported by any runtime's builtin fetch implementation.
 
-If you were using `httpAgent` for proxy support, check out the [new proxy documentation](https://github.com/anthropics/anthropic-sdk-typescript#configuring-proxies).
+If you were using `httpAgent` for proxy support, check out the [TypeScript SDK documentation](https://platform.claude.com/docs/en/api/sdks/typescript) for the new proxy configuration.
 
 Before:
 


### PR DESCRIPTION
## Summary

`MIGRATION.md` linked to two README anchors that no longer exist after the README was trimmed:

- `https://github.com/anthropics/anthropic-sdk-typescript#fetch-options`
- `https://github.com/anthropics/anthropic-sdk-typescript#configuring-proxies`

The current `README.md` has only six H2 headings (`Documentation`, `Installation`, `Getting started`, `Requirements`, `Contributing`, `License`); neither `fetch-options` nor `configuring-proxies` exists as an anchor anywhere in the repo. Both links 404 to the top of the README.

## Fix

Replaced both dead links with the canonical TypeScript SDK documentation URL already used by `README.md`:
`https://platform.claude.com/docs/en/api/sdks/typescript`.

Slight prose rewrite so the sentences read naturally without the anchor.

## Scope / safety

- `MIGRATION.md` is hand-written (no `File generated from our OpenAPI spec by Stainless.` header). It is **manual, not Stainless-generated**.
- Pure docs fix. No code change, no build/test impact.
- Same class of bug previously fixed on the Python SDK side.

## Test plan

- [x] Verified the two original anchors do not exist in `README.md`
- [x] Verified the replacement URL is the same one `README.md` already points at for full documentation

🤖 Generated with [Claude Code](https://claude.com/claude-code)