### PR TITLE
ci: migrate claude.yml to Workload Identity Federation auth

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -32,9 +32,15 @@ jobs:
 
       - name: Run Claude Code
         id: claude
-        uses: anthropics/claude-code-action@v1
+        uses: anthropics/claude-code-action@bbfaf8e1ffe3e688f7ab65ceee78de241e24a238 # v1.0.132 (>=v1.0.130 for WIF inputs)
         with:
-          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          # Anthropic auth via Workload Identity Federation — the action
+          # exchanges this job's GitHub OIDC token (id-token: write above)
+          # for a short-lived access token instead of a static API key.
+          # See https://github.com/anthropics/claude-code-action/blob/main/docs/setup.md
+          anthropic_federation_rule_id: fdrl_01FjcU2XNrTp2Q627GuU4wQY
+          anthropic_organization_id: 1ec12c5c-6542-4da8-bf2f-c15919aef01c
+          anthropic_service_account_id: svac_015WxdipDLEkv4CE2jVCq4tX
 
           # This is an optional setting that allows Claude to read CI results on PRs
           additional_permissions: |


### PR DESCRIPTION
Replaces the static `ANTHROPIC_API_KEY` repo secret with Workload Identity Federation: `claude-code-action` exchanges this job's GitHub OIDC token for a short-lived access token instead of reading a long-lived key.

- The federation rule is bound to this repository (repository_id-pinned), so the IDs below are repo-specific and not reusable elsewhere.
- Pins `claude-code-action` to v1.0.132 — the WIF inputs (`anthropic_federation_rule_id` etc.) landed in v1.0.130.
- `permissions: id-token: write` was already present.
- No `anthropic_workspace_id` — the rule targets the org's default workspace, so the input is optional (per the action's [docs/setup.md](https://github.com/anthropics/claude-code-action/blob/main/docs/setup.md)).

Once merged, the `ANTHROPIC_API_KEY` repo secret can be removed.