### PR TITLE
fix: buffer streamed text deltas

### DIFF
--- a/src/lib/BetaMessageStream.ts
+++ b/src/lib/BetaMessageStream.ts
@@ -44,11 +44,75 @@ type MessageStreamEventListeners<Event extends keyof MessageStreamEvents> = {
 }[];
 
 const JSON_BUF_PROPERTY = '__json_buf';
+const TEXT_CHUNKS_PROPERTY = '__text_chunks';
+const TEXT_SNAPSHOT_PROPERTY = '__text_snapshot';
 
 export type TracksToolInput = BetaToolUseBlock | BetaServerToolUseBlock | BetaMCPToolUseBlock;
 
 function tracksToolInput(content: BetaContentBlock): content is TracksToolInput {
   return content.type === 'tool_use' || content.type === 'server_tool_use' || content.type === 'mcp_tool_use';
+}
+
+function appendTextDelta(content: BetaTextBlock, text: string): void {
+  let chunks = (content as any)[TEXT_CHUNKS_PROPERTY] as string[] | undefined;
+  if (!chunks) {
+    const newChunks = content.text ? [content.text] : [];
+    chunks = newChunks;
+    Object.defineProperty(content, TEXT_CHUNKS_PROPERTY, {
+      value: newChunks,
+      enumerable: false,
+      writable: true,
+      configurable: true,
+    });
+    Object.defineProperty(content, 'text', {
+      get: () => newChunks.join(''),
+      set: (value: string) => {
+        newChunks.length = 0;
+        if (value) {
+          newChunks.push(value);
+        }
+      },
+      enumerable: true,
+      configurable: true,
+    });
+  }
+  chunks.push(text);
+}
+
+function appendTextSnapshot(content: BetaTextBlock, text: string): string {
+  let snapshot = (content as any)[TEXT_SNAPSHOT_PROPERTY] as string | undefined;
+  if (snapshot === undefined) {
+    const chunks = (content as any)[TEXT_CHUNKS_PROPERTY] as string[] | undefined;
+    snapshot = chunks ? chunks.join('') : content.text || '';
+    Object.defineProperty(content, TEXT_SNAPSHOT_PROPERTY, {
+      value: snapshot,
+      enumerable: false,
+      writable: true,
+      configurable: true,
+    });
+  } else {
+    snapshot += text;
+    (content as any)[TEXT_SNAPSHOT_PROPERTY] = snapshot;
+  }
+  return snapshot;
+}
+
+function materializeText(content: BetaContentBlock | undefined): void {
+  if (content?.type !== 'text') {
+    return;
+  }
+  const chunks = (content as any)[TEXT_CHUNKS_PROPERTY] as string[] | undefined;
+  if (!chunks) {
+    return;
+  }
+  Object.defineProperty(content, 'text', {
+    value: chunks.join(''),
+    enumerable: true,
+    writable: true,
+    configurable: true,
+  });
+  delete (content as any)[TEXT_CHUNKS_PROPERTY];
+  delete (content as any)[TEXT_SNAPSHOT_PROPERTY];
 }
 
 export class BetaMessageStream<ParsedT = null> implements AsyncIterable<BetaMessageStreamEvent> {
@@ -450,8 +514,8 @@ export class BetaMessageStream<ParsedT = null> implements AsyncIterable<BetaMess
         const content = messageSnapshot.content.at(-1)!;
         switch (event.delta.type) {
           case 'text_delta': {
-            if (content.type === 'text') {
-              this._emit('text', event.delta.text, content.text || '');
+            if (content.type === 'text' && this.#listeners.text?.length) {
+              this._emit('text', event.delta.text, appendTextSnapshot(content, event.delta.text));
             }
             break;
           }
@@ -611,10 +675,7 @@ export class BetaMessageStream<ParsedT = null> implements AsyncIterable<BetaMess
         switch (event.delta.type) {
           case 'text_delta': {
             if (snapshotContent?.type === 'text') {
-              snapshot.content[event.index] = {
-                ...snapshotContent,
-                text: (snapshotContent.text || '') + event.delta.text,
-              };
+              appendTextDelta(snapshotContent, event.delta.text);
             }
             break;
           }
@@ -689,6 +750,7 @@ export class BetaMessageStream<ParsedT = null> implements AsyncIterable<BetaMess
         return snapshot;
       }
       case 'content_block_stop':
+        materializeText(snapshot.content.at(event.index));
         return snapshot;
     }
   }

--- a/src/lib/MessageStream.ts
+++ b/src/lib/MessageStream.ts
@@ -41,11 +41,75 @@ type MessageStreamEventListeners<ParsedT, Event extends keyof MessageStreamEvent
 }[];
 
 const JSON_BUF_PROPERTY = '__json_buf';
+const TEXT_CHUNKS_PROPERTY = '__text_chunks';
+const TEXT_SNAPSHOT_PROPERTY = '__text_snapshot';
 
 export type TracksToolInput = ToolUseBlock | ServerToolUseBlock;
 
 function tracksToolInput(content: ContentBlock): content is TracksToolInput {
   return content.type === 'tool_use' || content.type === 'server_tool_use';
+}
+
+function appendTextDelta(content: TextBlock, text: string): void {
+  let chunks = (content as any)[TEXT_CHUNKS_PROPERTY] as string[] | undefined;
+  if (!chunks) {
+    const newChunks = content.text ? [content.text] : [];
+    chunks = newChunks;
+    Object.defineProperty(content, TEXT_CHUNKS_PROPERTY, {
+      value: newChunks,
+      enumerable: false,
+      writable: true,
+      configurable: true,
+    });
+    Object.defineProperty(content, 'text', {
+      get: () => newChunks.join(''),
+      set: (value: string) => {
+        newChunks.length = 0;
+        if (value) {
+          newChunks.push(value);
+        }
+      },
+      enumerable: true,
+      configurable: true,
+    });
+  }
+  chunks.push(text);
+}
+
+function appendTextSnapshot(content: TextBlock, text: string): string {
+  let snapshot = (content as any)[TEXT_SNAPSHOT_PROPERTY] as string | undefined;
+  if (snapshot === undefined) {
+    const chunks = (content as any)[TEXT_CHUNKS_PROPERTY] as string[] | undefined;
+    snapshot = chunks ? chunks.join('') : content.text || '';
+    Object.defineProperty(content, TEXT_SNAPSHOT_PROPERTY, {
+      value: snapshot,
+      enumerable: false,
+      writable: true,
+      configurable: true,
+    });
+  } else {
+    snapshot += text;
+    (content as any)[TEXT_SNAPSHOT_PROPERTY] = snapshot;
+  }
+  return snapshot;
+}
+
+function materializeText(content: ContentBlock | undefined): void {
+  if (content?.type !== 'text') {
+    return;
+  }
+  const chunks = (content as any)[TEXT_CHUNKS_PROPERTY] as string[] | undefined;
+  if (!chunks) {
+    return;
+  }
+  Object.defineProperty(content, 'text', {
+    value: chunks.join(''),
+    enumerable: true,
+    writable: true,
+    configurable: true,
+  });
+  delete (content as any)[TEXT_CHUNKS_PROPERTY];
+  delete (content as any)[TEXT_SNAPSHOT_PROPERTY];
 }
 
 export class MessageStream<ParsedT = null> implements AsyncIterable<MessageStreamEvent> {
@@ -458,8 +522,8 @@ export class MessageStream<ParsedT = null> implements AsyncIterable<MessageStrea
         const content = messageSnapshot.content.at(-1)!;
         switch (event.delta.type) {
           case 'text_delta': {
-            if (content.type === 'text') {
-              this._emit('text', event.delta.text, content.text || '');
+            if (content.type === 'text' && this.#listeners.text?.length) {
+              this._emit('text', event.delta.text, appendTextSnapshot(content, event.delta.text));
             }
             break;
           }
@@ -605,10 +669,7 @@ export class MessageStream<ParsedT = null> implements AsyncIterable<MessageStrea
         switch (event.delta.type) {
           case 'text_delta': {
             if (snapshotContent?.type === 'text') {
-              snapshot.content[event.index] = {
-                ...snapshotContent,
-                text: (snapshotContent.text || '') + event.delta.text,
-              };
+              appendTextDelta(snapshotContent, event.delta.text);
             }
             break;
           }
@@ -668,6 +729,7 @@ export class MessageStream<ParsedT = null> implements AsyncIterable<MessageStrea
         return snapshot;
       }
       case 'content_block_stop':
+        materializeText(snapshot.content.at(event.index));
         return snapshot;
     }
   }

--- a/tests/api-resources/BetaMessageStream.test.ts
+++ b/tests/api-resources/BetaMessageStream.test.ts
@@ -297,6 +297,72 @@ describe('BetaMessageStream class', () => {
     expect(finalText).toBe('Hello there!');
   });
 
+  it('handles many text deltas', async () => {
+    const { fetch, handleStreamEvents } = mockFetch();
+
+    const anthropic = new Anthropic({
+      apiKey: 'test-key',
+      fetch,
+      defaultHeaders: {
+        'anthropic-beta': 'fine-grained-tool-streaming-2025-05-14',
+      },
+    });
+    const chunks = Array.from({ length: 2048 }, (_, index) => String(index % 10));
+    const expectedText = chunks.join('');
+    const streamEvents: any[] = [
+      {
+        type: 'message_start',
+        message: {
+          id: 'msg_many_text_deltas',
+          type: 'message',
+          role: 'assistant',
+          content: [],
+          model: 'claude-opus-4-20250514',
+          stop_reason: null,
+          stop_sequence: null,
+          usage: { input_tokens: 1, output_tokens: 1 },
+        },
+      },
+      { type: 'content_block_start', index: 0, content_block: { type: 'text', text: '' } },
+      ...chunks.map((text) => ({
+        type: 'content_block_delta',
+        index: 0,
+        delta: { type: 'text_delta', text },
+      })),
+      { type: 'content_block_stop', index: 0 },
+      {
+        type: 'message_delta',
+        delta: { stop_reason: 'end_turn', stop_sequence: null, container: null },
+        usage: { output_tokens: chunks.length },
+      },
+      { type: 'message_stop' },
+    ];
+    handleStreamEvents(streamEvents);
+
+    const stream = anthropic.beta.messages.stream({
+      max_tokens: 4096,
+      model: 'claude-opus-4-20250514',
+      messages: [{ role: 'user', content: 'Repeat digits.' }],
+    });
+
+    let textSnapshot = '';
+    stream.on('text', (_textDelta, snapshot) => {
+      textSnapshot = snapshot;
+    });
+
+    for await (const _event of stream) {
+      // consume the stream
+    }
+
+    await stream.done();
+    const finalMessage = await stream.finalMessage();
+    const finalText = await stream.finalText();
+
+    expect(textSnapshot).toBe(expectedText);
+    expect(finalText).toBe(expectedText);
+    expect(finalMessage.content).toEqual([{ type: 'text', text: expectedText }]);
+  });
+
   it('handles tool use response fixture', async () => {
     const { fetch, handleStreamEvents } = mockFetch();
 

--- a/tests/api-resources/MessageStream.test.ts
+++ b/tests/api-resources/MessageStream.test.ts
@@ -198,6 +198,66 @@ describe('MessageStream class', () => {
     expect(finalText).toBe('Hello there!');
   });
 
+  it('handles many text deltas', async () => {
+    const { fetch, handleStreamEvents } = mockFetch();
+
+    const anthropic = new Anthropic({ apiKey: '...', fetch });
+    const chunks = Array.from({ length: 2048 }, (_, index) => String(index % 10));
+    const expectedText = chunks.join('');
+    const streamEvents: any[] = [
+      {
+        type: 'message_start',
+        message: {
+          id: 'msg_many_text_deltas',
+          type: 'message',
+          role: 'assistant',
+          content: [],
+          model: 'claude-opus-4-20250514',
+          stop_reason: null,
+          stop_sequence: null,
+          usage: { input_tokens: 1, output_tokens: 1 },
+        },
+      },
+      { type: 'content_block_start', index: 0, content_block: { type: 'text', text: '' } },
+      ...chunks.map((text) => ({
+        type: 'content_block_delta',
+        index: 0,
+        delta: { type: 'text_delta', text },
+      })),
+      { type: 'content_block_stop', index: 0 },
+      {
+        type: 'message_delta',
+        delta: { stop_reason: 'end_turn', stop_sequence: null },
+        usage: { output_tokens: chunks.length },
+      },
+      { type: 'message_stop' },
+    ];
+    handleStreamEvents(streamEvents);
+
+    const stream = anthropic.messages.stream({
+      max_tokens: 4096,
+      model: 'claude-opus-4-20250514',
+      messages: [{ role: 'user', content: 'Repeat digits.' }],
+    });
+
+    let textSnapshot = '';
+    stream.on('text', (_textDelta, snapshot) => {
+      textSnapshot = snapshot;
+    });
+
+    for await (const _event of stream) {
+      // consume the stream
+    }
+
+    await stream.done();
+    const finalMessage = await stream.finalMessage();
+    const finalText = await stream.finalText();
+
+    expect(textSnapshot).toBe(expectedText);
+    expect(finalText).toBe(expectedText);
+    expect(finalMessage.content).toEqual([{ type: 'text', text: expectedText }]);
+  });
+
   it('handles tool use response fixture', async () => {
     const { fetch, handleStreamEvents } = mockFetch();
 


### PR DESCRIPTION
Fixes #995.\n\nThis buffers streamed text deltas internally and materializes the final text when the content block stops, avoiding repeated string concatenation for long responses.\n\nChecked with:\n- npx --no-install jest tests/api-resources/MessageStream.test.ts tests/api-resources/BetaMessageStream.test.ts --runInBand\n- npx --no-install eslint src/lib/MessageStream.ts src/lib/BetaMessageStream.ts tests/api-resources/MessageStream.test.ts tests/api-resources/BetaMessageStream.test.ts\n- npx --no-install tsc --noEmit\n- npx --no-install prettier --check src/lib/MessageStream.ts src/lib/BetaMessageStream.ts tests/api-resources/MessageStream.test.ts tests/api-resources/BetaMessageStream.test.ts\n- git diff --check