### PR TITLE
fix(beta/skills): preserve filenames in versions.create multipart upload

### DIFF
--- a/src/resources/beta/skills/versions.ts
+++ b/src/resources/beta/skills/versions.ts
@@ -39,6 +39,7 @@ export class Versions extends APIResource {
           ]),
         },
         this._client,
+        false,
       ),
     );
   }


### PR DESCRIPTION
Fixes #1066

Why
`client.beta.skills.versions.create()` fails with a 400 error "SKILL.md file must be exactly in the top-level folder" because the SDK strips filenames from the multipart upload parts. The sibling `client.beta.skills.create()` works correctly because it passes `stripFilenames=false` to `multipartFormRequestOptions()`, but `versions.create` does not — so it picks up the default `stripFilenames=true`.

Changes
Added `false` as the third argument to `multipartFormRequestOptions()` in `versions.create()`, matching the pattern already used in `skills.create()`.

Updated component: `src/resources/beta/skills/versions.ts`

Testing
- `client.beta.skills.versions.create()` now sends filenames in multipart parts
- The API can correctly identify which uploaded file is SKILL.md
- Behavior now matches `skills.create()` exactly

Surface area
- Beta / Skills / Versions
- Bug fix