### PR TITLE
fix: propagate container.id across toolRunner iterations

### DIFF
--- a/src/lib/tools/BetaToolRunner.ts
+++ b/src/lib/tools/BetaToolRunner.ts
@@ -196,11 +196,15 @@ export class BetaToolRunner<Stream extends boolean> {
             yield this.#message as any;
           }
 
+          const message = await this.#message;
+          if (message.container?.id) {
+            this.#state.params.container = message.container.id;
+          }
+
           const isCompacted = await this.#checkAndCompact();
           if (!isCompacted) {
             if (!this.#mutated) {
-              const { role, content } = await this.#message;
-              this.#state.params.messages.push({ role, content });
+              this.#state.params.messages.push({ role: message.role, content: message.content });
             }
 
             const toolMessage = await this.#generateToolResponse(this.#state.params.messages.at(-1)!);

--- a/src/lib/tools/ToolRunner.ts
+++ b/src/lib/tools/ToolRunner.ts
@@ -107,9 +107,13 @@ export class BetaToolRunner<Stream extends boolean> {
             yield this.#message as any;
           }
 
+          const message = await this.#message;
+          if (message.container?.id) {
+            this.#state.params.container = message.container.id;
+          }
+
           if (!this.#mutated) {
-            const { role, content } = await this.#message;
-            this.#state.params.messages.push({ role, content });
+            this.#state.params.messages.push({ role: message.role, content: message.content });
           }
 
           const toolMessage = await this.#generateToolResponse(this.#state.params.messages.at(-1)!);

--- a/tests/lib/tools/ToolRunner.test.ts
+++ b/tests/lib/tools/ToolRunner.test.ts
@@ -1472,4 +1472,171 @@ describe('ToolRunner', () => {
       expect(capturedContext!.signal).toBe(controller.signal);
     });
   });
+
+  describe('container.id propagation', () => {
+    it('forwards container.id from response to next request', async () => {
+      const { fetch, handleRequest } = mockFetch();
+      const client = new Anthropic({ apiKey: 'test-key', fetch, maxRetries: 0 });
+
+      const capturedBodies: any[] = [];
+
+      const makeMessage = (
+        content: BetaContentBlock[],
+        container: BetaMessage['container'] = null,
+      ): BetaMessage => ({
+        id: `msg_${capturedBodies.length}`,
+        type: 'message',
+        role: 'assistant',
+        content,
+        model: 'claude-3-5-sonnet-latest',
+        stop_details: null,
+        stop_reason: content.some((b) => b.type === 'tool_use') ? 'tool_use' : 'end_turn',
+        stop_sequence: null,
+        container,
+        context_management: null,
+        diagnostics: null,
+        usage: {
+          input_tokens: 10,
+          output_tokens: 20,
+          cache_creation: null,
+          cache_creation_input_tokens: null,
+          cache_read_input_tokens: null,
+          server_tool_use: null,
+          service_tier: null,
+          inference_geo: null,
+          iterations: null,
+          speed: null,
+        },
+      });
+
+      // First request: assistant calls a tool, response includes container
+      handleRequest(async (_req, init) => {
+        capturedBodies.push(JSON.parse(init?.body as string));
+        return new Response(
+          JSON.stringify(
+            makeMessage([getWeatherToolUse('Berlin')], {
+              id: 'container_abc123',
+              expires_at: '2026-06-01T00:00:00Z',
+              skills: null,
+            }),
+          ),
+          { status: 200, headers: { 'content-type': 'application/json' } },
+        );
+      });
+
+      // Second request: tool result sent back - should include container
+      handleRequest(async (_req, init) => {
+        capturedBodies.push(JSON.parse(init?.body as string));
+        return new Response(JSON.stringify(makeMessage([getTextContent('Done')])), {
+          status: 200,
+          headers: { 'content-type': 'application/json' },
+        });
+      });
+
+      const runner = client.beta.messages.toolRunner({
+        model: 'claude-3-5-sonnet-latest',
+        max_tokens: 1000,
+        tools: [weatherTool],
+        messages: [{ role: 'user', content: 'Weather in Berlin?' }],
+      });
+
+      await runner.runUntilDone();
+
+      expect(capturedBodies).toHaveLength(2);
+      expect(capturedBodies[0]!.container).toBeUndefined();
+      expect(capturedBodies[1]!.container).toBe('container_abc123');
+    });
+
+    it('forwards container.id in streaming mode', async () => {
+      const { fetch, handleRequest } = mockFetch();
+      const client = new Anthropic({ apiKey: 'test-key', fetch, maxRetries: 0 });
+
+      const capturedBodies: any[] = [];
+
+      const makeMessage = (
+        content: BetaContentBlock[],
+        container: BetaMessage['container'] = null,
+      ): BetaMessage => ({
+        id: `msg_${capturedBodies.length}`,
+        type: 'message',
+        role: 'assistant',
+        content,
+        model: 'claude-3-5-sonnet-latest',
+        stop_details: null,
+        stop_reason: content.some((b) => b.type === 'tool_use') ? 'tool_use' : 'end_turn',
+        stop_sequence: null,
+        container,
+        context_management: null,
+        diagnostics: null,
+        usage: {
+          input_tokens: 10,
+          output_tokens: 20,
+          cache_creation: null,
+          cache_creation_input_tokens: null,
+          cache_read_input_tokens: null,
+          server_tool_use: null,
+          service_tier: null,
+          inference_geo: null,
+          iterations: null,
+          speed: null,
+        },
+      });
+
+      // First request (streaming): tool call with container
+      handleRequest(async (_req, init) => {
+        capturedBodies.push(JSON.parse(init?.body as string));
+        const msg = makeMessage([getWeatherToolUse('Berlin')], {
+          id: 'container_stream_456',
+          expires_at: '2026-06-01T00:00:00Z',
+          skills: null,
+        });
+        const events = betaMessageToStreamEvents(msg);
+        const { PassThrough } = require('stream');
+        const stream = new PassThrough();
+        (async () => {
+          for (const event of events) {
+            stream.write(`event: ${event.type}\n`);
+            stream.write(`data: ${JSON.stringify(event)}\n\n`);
+          }
+          stream.end(`\n`);
+        })();
+        return new Response(stream, {
+          headers: { 'Content-Type': 'text/event-stream', 'Transfer-Encoding': 'chunked' },
+        });
+      });
+
+      // Second request (streaming): final response
+      handleRequest(async (_req, init) => {
+        capturedBodies.push(JSON.parse(init?.body as string));
+        const msg = makeMessage([getTextContent('Done')]);
+        const events = betaMessageToStreamEvents(msg);
+        const { PassThrough } = require('stream');
+        const stream = new PassThrough();
+        (async () => {
+          for (const event of events) {
+            stream.write(`event: ${event.type}\n`);
+            stream.write(`data: ${JSON.stringify(event)}\n\n`);
+          }
+          stream.end(`\n`);
+        })();
+        return new Response(stream, {
+          headers: { 'Content-Type': 'text/event-stream', 'Transfer-Encoding': 'chunked' },
+        });
+      });
+
+      const runner = client.beta.messages.toolRunner({
+        model: 'claude-3-5-sonnet-latest',
+        max_tokens: 1000,
+        tools: [weatherTool],
+        messages: [{ role: 'user', content: 'Weather in Berlin?' }],
+        stream: true,
+      });
+
+      await runner.runUntilDone();
+
+      expect(capturedBodies).toHaveLength(2);
+      expect(capturedBodies[0]!.container).toBeUndefined();
+      expect(capturedBodies[1]!.container).toBe('container_stream_456');
+    });
+  });
 });


### PR DESCRIPTION
## Summary

Fixes #964 — `toolRunner` does not propagate `container.id` across iterations, causing a hard error when using `code_execution` with client-side `betaTool`s.

### Root cause

When the API returns a response with a `container` object (created by `code_execution`), the `container.id` must be included in subsequent requests so the API can reuse the same container. Neither `BetaToolRunner` nor the legacy `ToolRunner` extracted this value from the response, so the next iteration sent a request without `container`, triggering:

```json
{"type":"invalid_request_error","message":"container_id is required when there are pending tool uses generated by code execution with tools."}
```

The only workaround (`setMessagesParams`) also didn't work correctly — setting `container` via the mutator triggered the `#mutated` flag, which prevented the assistant message from being pushed to the conversation history, causing an infinite loop (Bug 2 in the issue).

### Fix

After awaiting each response, extract `container.id` and set it on `this.#state.params.container` before the `#mutated` check. This ensures:

1. The container is propagated regardless of whether the user called `setMessagesParams`
2. Users no longer need the broken `setMessagesParams` workaround
3. The fix is minimal — 4 lines of logic in each runner

Applied to both `BetaToolRunner` and the legacy `ToolRunner`.

## Test plan

- [x] `forwards container.id from response to next request` — non-streaming mode, verifies second request body contains `container`
- [x] `forwards container.id in streaming mode` — same verification via SSE streaming
- [x] All 30 existing ToolRunner tests pass