### PR TITLE
fix(streaming): use event.index instead of at(-1) for content block lookup

### DIFF
--- a/src/lib/BetaMessageStream.ts
+++ b/src/lib/BetaMessageStream.ts
@@ -447,7 +447,7 @@ export class BetaMessageStream<ParsedT = null> implements AsyncIterable<BetaMess
 
     switch (event.type) {
       case 'content_block_delta': {
-        const content = messageSnapshot.content.at(-1)!;
+        const content = messageSnapshot.content.at(event.index)!;
         switch (event.delta.type) {
           case 'text_delta': {
             if (content.type === 'text') {
@@ -499,7 +499,7 @@ export class BetaMessageStream<ParsedT = null> implements AsyncIterable<BetaMess
         break;
       }
       case 'content_block_stop': {
-        this._emit('contentBlock', messageSnapshot.content.at(-1)!);
+        this._emit('contentBlock', messageSnapshot.content.at(event.index)!);
         break;
       }
       case 'message_start': {

--- a/src/lib/MessageStream.ts
+++ b/src/lib/MessageStream.ts
@@ -455,7 +455,7 @@ export class MessageStream<ParsedT = null> implements AsyncIterable<MessageStrea
 
     switch (event.type) {
       case 'content_block_delta': {
-        const content = messageSnapshot.content.at(-1)!;
+        const content = messageSnapshot.content.at(event.index)!;
         switch (event.delta.type) {
           case 'text_delta': {
             if (content.type === 'text') {
@@ -498,7 +498,7 @@ export class MessageStream<ParsedT = null> implements AsyncIterable<MessageStrea
         break;
       }
       case 'content_block_stop': {
-        this._emit('contentBlock', messageSnapshot.content.at(-1)!);
+        this._emit('contentBlock', messageSnapshot.content.at(event.index)!);
         break;
       }
       case 'message_start': {


### PR DESCRIPTION
## Summary
- `#addStreamEvent` used `.at(-1)` to look up the current content block for event emission, while `#accumulateMessage` correctly used `event.index`
- This would return the wrong content block if deltas arrived for a non-final block in multi-block messages
- The Python SDK already uses `event.index` in the equivalent code path

Affects both `MessageStream.ts` and `BetaMessageStream.ts` (`content_block_delta` and `content_block_stop` handlers).