### PR TITLE
feat(bedrock): support token counting

### DIFF
--- a/packages/bedrock-sdk/src/client.ts
+++ b/packages/bedrock-sdk/src/client.ts
@@ -1,5 +1,6 @@
 import { BaseAnthropic, ClientOptions as CoreClientOptions } from '@anthropic-ai/sdk/client';
 import * as Resources from '@anthropic-ai/sdk/resources/index';
+import { APIPromise } from '@anthropic-ai/sdk/core/api-promise';
 import { AwsCredentialIdentityProvider } from '@smithy/types';
 import { getAuthHeaders } from './core/auth';
 import { Stream } from './core/streaming';
@@ -10,11 +11,16 @@ import { buildHeaders } from './internal/headers';
 import { FinalizedRequestInit } from './internal/types';
 import { path } from './internal/utils/path';
 import { loggerFor } from './internal/utils/log';
+import { toBase64 } from './internal/utils/base64';
 
 export { BaseAnthropic } from '@anthropic-ai/sdk/client';
 
 const DEFAULT_VERSION = 'bedrock-2023-05-31';
 const MODEL_ENDPOINTS = new Set<string>(['/v1/complete', '/v1/messages', '/v1/messages?beta=true']);
+const COUNT_TOKENS_ENDPOINTS = new Set<string>([
+  '/v1/messages/count_tokens',
+  '/v1/messages/count_tokens?beta=true',
+]);
 
 export type ClientOptions = Omit<CoreClientOptions, 'apiKey' | 'authToken'> & {
   awsSecretKey?: string | null | undefined;
@@ -203,14 +209,47 @@ export class AnthropicBedrock extends BaseAnthropic {
       }
     }
 
+    if (COUNT_TOKENS_ENDPOINTS.has(options.path) && options.method === 'post') {
+      if (!isObj(options.body)) {
+        throw new Error('Expected request body to be an object for post /v1/messages/count_tokens');
+      }
+
+      const model = options.body['model'] as string;
+      options.body['model'] = undefined;
+
+      options.path = path`/model/${model}/count-tokens`;
+      options.body = {
+        input: {
+          invokeModel: {
+            body: toBase64(JSON.stringify(options.body)),
+          },
+        },
+      };
+    }
+
     return super.buildRequest(options);
   }
 }
 
 /**
- * The Bedrock API does not currently support token counting or the Batch API.
+ * The Bedrock CountTokens API returns `inputTokens` instead of `input_tokens`,
+ * so remap it to match the first-party API response shape.
  */
-type MessagesResource = Omit<Resources.Messages, 'batches' | 'countTokens'>;
+function patchCountTokensResponse(resource: { countTokens: (...args: any[]) => APIPromise<any> }): void {
+  const originalCountTokens = resource.countTokens.bind(resource);
+  resource.countTokens = (...args: any[]) =>
+    originalCountTokens(...args)._thenUnwrap((data: unknown) => {
+      if (isObj(data) && typeof data['inputTokens'] === 'number') {
+        return { input_tokens: data['inputTokens'] };
+      }
+      return data;
+    });
+}
+
+/**
+ * The Bedrock API does not currently support the Batch API.
+ */
+type MessagesResource = Omit<Resources.Messages, 'batches'>;
 
 function makeMessagesResource(client: AnthropicBedrock): MessagesResource {
   const resource = new Resources.Messages(client);
@@ -218,17 +257,16 @@ function makeMessagesResource(client: AnthropicBedrock): MessagesResource {
   // @ts-expect-error we're deleting non-optional properties
   delete resource.batches;
 
-  // @ts-expect-error we're deleting non-optional properties
-  delete resource.countTokens;
+  patchCountTokensResponse(resource);
 
   return resource;
 }
 
 /**
- * The Bedrock API does not currently support prompt caching, token counting or the Batch API.
+ * The Bedrock API does not currently support prompt caching or the Batch API.
  */
 type BetaResource = Omit<Resources.Beta, 'promptCaching' | 'messages'> & {
-  messages: Omit<Resources.Beta['messages'], 'batches' | 'countTokens'>;
+  messages: Omit<Resources.Beta['messages'], 'batches'>;
 };
 
 function makeBetaResource(client: AnthropicBedrock): BetaResource {
@@ -240,8 +278,7 @@ function makeBetaResource(client: AnthropicBedrock): BetaResource {
   // @ts-expect-error we're deleting non-optional properties
   delete resource.messages.batches;
 
-  // @ts-expect-error we're deleting non-optional properties
-  delete resource.messages.countTokens;
+  patchCountTokensResponse(resource.messages);
 
   return resource;
 }

--- a/packages/bedrock-sdk/tests/client.test.ts
+++ b/packages/bedrock-sdk/tests/client.test.ts
@@ -114,6 +114,78 @@ describe('Bedrock model ARN URL encoding integration test', () => {
   });
 });
 
+describe('Bedrock token counting integration test', () => {
+  const countTokensFetch = jest.fn().mockImplementation(() => {
+    return Promise.resolve({
+      ok: true,
+      status: 200,
+      statusText: 'OK',
+      headers: new Headers({ 'content-type': 'application/json' }),
+      json: () => Promise.resolve({ inputTokens: 42 }),
+      text: () => Promise.resolve('{"inputTokens": 42}'),
+    });
+  });
+
+  beforeEach(() => {
+    global.fetch = countTokensFetch;
+    countTokensFetch.mockClear();
+  });
+
+  afterEach(() => {
+    global.fetch = originalFetch;
+  });
+
+  test('routes count_tokens to the Bedrock CountTokens endpoint and remaps the response', async () => {
+    const { AnthropicBedrock } = require('../src');
+
+    const client = new AnthropicBedrock({
+      awsRegion: 'us-east-1',
+      baseURL: 'http://localhost:4010',
+    });
+
+    const count = await client.messages.countTokens({
+      model: 'anthropic.claude-3-5-sonnet-20241022-v2:0',
+      messages: [{ content: 'Test message', role: 'user' }],
+    });
+
+    expect(count.input_tokens).toBe(42);
+
+    expect(countTokensFetch).toHaveBeenCalled();
+    const fetchUrl = countTokensFetch.mock.calls[0][0];
+    expect(fetchUrl).toBe(
+      'http://localhost:4010/model/anthropic.claude-3-5-sonnet-20241022-v2:0/count-tokens',
+    );
+
+    const requestBody = JSON.parse(countTokensFetch.mock.calls[0][1].body);
+    const innerBody = JSON.parse(Buffer.from(requestBody.input.invokeModel.body, 'base64').toString());
+    expect(innerBody).toEqual({
+      messages: [{ content: 'Test message', role: 'user' }],
+      anthropic_version: 'bedrock-2023-05-31',
+    });
+  });
+
+  test('supports token counting on the beta messages resource', async () => {
+    const { AnthropicBedrock } = require('../src');
+
+    const client = new AnthropicBedrock({
+      awsRegion: 'us-east-1',
+      baseURL: 'http://localhost:4010',
+    });
+
+    const count = await client.beta.messages.countTokens({
+      model: 'anthropic.claude-3-5-sonnet-20241022-v2:0',
+      messages: [{ content: 'Test message', role: 'user' }],
+    });
+
+    expect(count.input_tokens).toBe(42);
+
+    const fetchUrl = countTokensFetch.mock.calls[0][0];
+    expect(fetchUrl).toBe(
+      'http://localhost:4010/model/anthropic.claude-3-5-sonnet-20241022-v2:0/count-tokens',
+    );
+  });
+});
+
 describe('AnthropicBedrock constructor deprecation warnings', () => {
   let consoleWarnSpy: jest.SpyInstance;
 


### PR DESCRIPTION
Amazon Bedrock now supports token counting via the [CountTokens API](https://docs.aws.amazon.com/bedrock/latest/APIReference/API_runtime_CountTokens.html), so the Bedrock client no longer needs to strip `countTokens` from its resources.

TypeScript counterpart to anthropics/anthropic-sdk-python#1650.

## What changed

- `buildRequest` now rewrites `POST /v1/messages/count_tokens` (and the `?beta=true` variant) to Bedrock's `POST /model/{modelId}/count-tokens` endpoint. The Anthropic-format request body is wrapped in Bedrock's `CountTokensInput` shape as a base64-encoded `invokeModel` body. The model ID is URL-quoted the same way as for `create`, so inference profile ARNs work.
- Instead of deleting `countTokens` from the messages resources, the client now wraps it to map Bedrock's `{"inputTokens": N}` response to `{"input_tokens": N}`, so callers get the same `MessageTokensCount` shape as the first-party API.
- `countTokens` is available on both `client.messages` and `client.beta.messages` (the `MessagesResource` / `BetaResource` types no longer omit it).

## Usage

```ts
import { AnthropicBedrock } from '@anthropic-ai/bedrock-sdk';

const client = new AnthropicBedrock();
const count = await client.messages.countTokens({
  model: 'anthropic.claude-3-5-sonnet-20241022-v2:0',
  messages: [{ role: 'user', content: 'Hello, world' }],
});
console.log(count.input_tokens);
```

## Tests

Added integration-style tests covering the URL rewrite, the base64-wrapped request body, and the response remap for both the main and beta resources. All bedrock-sdk tests pass (7 passed), and the package builds cleanly.
