### PR TITLE
feat(examples): add MCP agent trust check using TWZRD Agent Intel

### DIFF
--- a/examples/mcp-agent-trust.ts
+++ b/examples/mcp-agent-trust.ts
@@ -1,0 +1,60 @@
+#!/usr/bin/env -S npm run tsn -T
+/**
+ * Example: verify agent trust before taking action
+ *
+ * Uses the TWZRD Agent Intel MCP server (https://intel.twzrd.xyz) to score
+ * an AI agent wallet before allowing it to proceed. The server exposes:
+ *   - score_agent(wallet)       - free trust score (0-100)
+ *   - preflight_check(wallet)   - free pass/fail gate
+ *   - get_trust_receipt(wallet) - paid x402 on-chain receipt
+ *
+ * Run:
+ *   ANTHROPIC_API_KEY=sk-... yarn tsn -T examples/mcp-agent-trust.ts
+ */
+
+import Anthropic from "@anthropic-ai/sdk";
+
+const anthropic = new Anthropic(); // reads ANTHROPIC_API_KEY from env
+
+const AGENT_WALLET = "D1QkbFJKiPsymJ65RKHhF6DFB8sPMfpBaFBzuHKfJGWi"; // example wallet
+
+const main = async () => {
+  const stream = anthropic.beta.messages.stream(
+    {
+      model: "claude-opus-4-5",
+      max_tokens: 512,
+      mcp_servers: [
+        {
+          type: "url",
+          url: "https://intel.twzrd.xyz/mcp",
+          name: "twzrd-agent-intel",
+          // No auth token needed — score_agent and preflight_check are free
+        },
+      ],
+      messages: [
+        {
+          role: "user",
+          content: `Use the twzrd-agent-intel MCP server to run preflight_check for wallet ${AGENT_WALLET}. If the check passes, confirm the agent is trusted. If it fails, explain why the agent should be blocked.`,
+        },
+      ],
+    },
+    {
+      headers: {
+        "anthropic-beta": "mcp-client-2025-04-04",
+      },
+    },
+  );
+
+  process.stdout.write("\nAgent trust check result:\n");
+  for await (const event of stream) {
+    if (
+      event.type === "content_block_delta" &&
+      event.delta.type === "text_delta"
+    ) {
+      process.stdout.write(event.delta.text);
+    }
+  }
+  process.stdout.write("\n");
+};
+
+main();


### PR DESCRIPTION
## What

Adds `examples/mcp-agent-trust.ts` — a minimal working example showing how to use an external MCP server ([TWZRD Agent Intel](https://intel.twzrd.xyz)) to score an AI agent wallet before taking action.

This complements the existing `examples/mcp.ts` by demonstrating a real-world use case: pre-flight trust verification for autonomous agents.

## Why

The `mcp.ts` example uses a generic echo/add server. This example shows a practical pattern — checking whether an AI agent (identified by wallet address) should be trusted before executing sensitive operations. It is directly useful to teams building multi-agent pipelines with Claude.

## Tools used

| Tool | Auth | Description |
|------|------|-------------|
| `score_agent(wallet)` | Free | Trust score 0–100 |
| `preflight_check(wallet)` | Free | Pass/fail gate |
| `get_trust_receipt(wallet)` | Paid (x402) | On-chain receipt |

## Testing

```sh
ANTHROPIC_API_KEY=sk-... yarn tsn -T examples/mcp-agent-trust.ts
```

No additional dependencies — the MCP server is remote (`https://intel.twzrd.xyz/mcp`, streamable-http).