### PR TITLE
feat(lib): add `getContextWindowUtilization` helper

### DIFF
--- a/src/lib/context-window.ts
+++ b/src/lib/context-window.ts
@@ -1,0 +1,160 @@
+/**
+ * Client-side helper for computing context-window utilization from a Messages
+ * API response.
+ *
+ * Addresses the use case described in issue #1064 — `usage.input_tokens` alone
+ * doesn't make under-utilization visible because the denominator (the model's
+ * total context window) isn't returned alongside it. This helper provides that
+ * denominator using a built-in lookup table of known model identifiers and a
+ * computed utilization ratio that sums input + cache-read + cache-creation
+ * tokens against the model's maximum.
+ *
+ * Usage:
+ * ```ts
+ *   const message = await client.messages.create({ ... });
+ *   const { contextWindow, utilization } = getContextWindowUtilization({
+ *     model: message.model,
+ *     usage: message.usage,
+ *   });
+ *   // → { contextWindow: 200000, utilization: 0.146 }
+ * ```
+ *
+ * The lookup can be extended or overridden for unknown / forthcoming models:
+ * ```ts
+ *   getContextWindowUtilization({
+ *     model: 'my-internal-tuned-model',
+ *     usage,
+ *     contextWindowOverride: 500_000,
+ *   });
+ * ```
+ */
+
+/** Subset of `Usage` fields the helper consumes. Mirrors the shape returned
+ * by `Messages` and `Beta.Messages` responses without taking a hard dependency
+ * on the generated `Usage` type, so the helper stays compatible across SDK
+ * regenerations. */
+export interface ContextWindowUsage {
+  input_tokens: number;
+  output_tokens?: number | null;
+  cache_creation_input_tokens?: number | null;
+  cache_read_input_tokens?: number | null;
+}
+
+export interface ContextWindowUtilization {
+  /** Total context window for the model, in tokens. */
+  contextWindow: number;
+  /** Ratio in `[0, 1]` of input-side tokens used vs. the model's context window. */
+  utilization: number;
+  /** Input + cache-read + cache-creation tokens that count against the input context budget. */
+  inputBudgetUsed: number;
+}
+
+export interface GetContextWindowUtilizationOptions {
+  model: string;
+  usage: ContextWindowUsage;
+  /**
+   * Override for the model's context window in tokens. Required when the model
+   * identifier isn't recognized; takes precedence over the built-in lookup.
+   */
+  contextWindowOverride?: number;
+  /**
+   * Custom lookup map merged on top of the built-in defaults. Useful for
+   * forthcoming model identifiers, aliases, or proxied/tuned deployments.
+   */
+  modelContextWindows?: Readonly<Record<string, number>>;
+}
+
+/**
+ * Built-in lookup of Claude model identifier → maximum context window in tokens.
+ * Documented at https://docs.anthropic.com/en/docs/about-claude/models. Most
+ * production Claude models share the 200_000-token window; opt-in 1M-token
+ * extended contexts are not enabled by default and aren't reflected here.
+ */
+export const DEFAULT_MODEL_CONTEXT_WINDOWS: Readonly<Record<string, number>> = {
+  // Claude 4.x family
+  'claude-opus-4-8': 200_000,
+  'claude-opus-4-7': 200_000,
+  'claude-opus-4-6': 200_000,
+  'claude-opus-4-5': 200_000,
+  'claude-opus-4-5-20251101': 200_000,
+  'claude-opus-4-1': 200_000,
+  'claude-opus-4-1-20250805': 200_000,
+  'claude-opus-4-0': 200_000,
+  'claude-opus-4-20250514': 200_000,
+  'claude-sonnet-4-6': 200_000,
+  'claude-sonnet-4-5': 200_000,
+  'claude-sonnet-4-5-20250929': 200_000,
+  'claude-sonnet-4-0': 200_000,
+  'claude-sonnet-4-20250514': 200_000,
+  'claude-haiku-4-5': 200_000,
+  'claude-haiku-4-5-20251001': 200_000,
+  // Preview / specialty
+  'claude-mythos-preview': 200_000,
+  'claude-mythos-5': 200_000,
+  'claude-fable-5': 200_000,
+  // Legacy
+  'claude-3-haiku-20240307': 200_000,
+};
+
+/** Resolve a model identifier to its context window, consulting (in order)
+ * the explicit override, the caller-supplied map, then the built-in defaults. */
+export function getContextWindowForModel(
+  model: string,
+  options?: {
+    contextWindowOverride?: number;
+    modelContextWindows?: Readonly<Record<string, number>>;
+  },
+): number | undefined {
+  if (options?.contextWindowOverride !== undefined) {
+    return options.contextWindowOverride;
+  }
+  if (options?.modelContextWindows && model in options.modelContextWindows) {
+    return options.modelContextWindows[model];
+  }
+  if (model in DEFAULT_MODEL_CONTEXT_WINDOWS) {
+    return DEFAULT_MODEL_CONTEXT_WINDOWS[model];
+  }
+  return undefined;
+}
+
+/**
+ * Compute the input-side context-window utilization for a Messages API
+ * response. `utilization` is clamped to `[0, 1]` and the input budget includes
+ * cache-creation and cache-read tokens since both count against the input
+ * context (cache-read at a discount on cost, but the same physical bytes).
+ *
+ * @throws if the model isn't recognized and no `contextWindowOverride` was
+ * provided. The thrown error names the unknown model so callers can extend
+ * `modelContextWindows` or pass `contextWindowOverride`.
+ */
+export function getContextWindowUtilization(
+  options: GetContextWindowUtilizationOptions,
+): ContextWindowUtilization {
+  const contextWindow = getContextWindowForModel(options.model, {
+    contextWindowOverride: options.contextWindowOverride,
+    modelContextWindows: options.modelContextWindows,
+  });
+  if (contextWindow === undefined) {
+    throw new Error(
+      `Unknown model "${options.model}" — pass \`contextWindowOverride\` or extend \`modelContextWindows\`.`,
+    );
+  }
+  if (contextWindow <= 0) {
+    throw new Error(
+      `Invalid context window ${contextWindow} for model "${options.model}" — must be a positive integer.`,
+    );
+  }
+
+  const inputBudgetUsed =
+    options.usage.input_tokens +
+    (options.usage.cache_creation_input_tokens ?? 0) +
+    (options.usage.cache_read_input_tokens ?? 0);
+
+  const utilization = Math.min(1, Math.max(0, inputBudgetUsed / contextWindow));
+
+  return {
+    contextWindow,
+    inputBudgetUsed,
+    utilization,
+  };
+}

--- a/tests/lib/context-window.test.ts
+++ b/tests/lib/context-window.test.ts
@@ -1,0 +1,120 @@
+import {
+  DEFAULT_MODEL_CONTEXT_WINDOWS,
+  getContextWindowForModel,
+  getContextWindowUtilization,
+} from '../../src/lib/context-window';
+
+describe('context-window helper', () => {
+  describe('getContextWindowForModel', () => {
+    it('returns the built-in value for known models', () => {
+      expect(getContextWindowForModel('claude-opus-4-5')).toBe(200_000);
+      expect(getContextWindowForModel('claude-haiku-4-5-20251001')).toBe(200_000);
+    });
+
+    it('returns undefined for unknown models without an override', () => {
+      expect(getContextWindowForModel('some-other-model')).toBeUndefined();
+    });
+
+    it('honours an explicit override over the built-ins', () => {
+      expect(
+        getContextWindowForModel('claude-opus-4-5', { contextWindowOverride: 1_000_000 }),
+      ).toBe(1_000_000);
+    });
+
+    it('consults the caller-supplied map before falling through to defaults', () => {
+      expect(
+        getContextWindowForModel('my-tuned-deployment', {
+          modelContextWindows: { 'my-tuned-deployment': 50_000 },
+        }),
+      ).toBe(50_000);
+    });
+  });
+
+  describe('getContextWindowUtilization', () => {
+    it('computes utilization for plain input + output tokens', () => {
+      const result = getContextWindowUtilization({
+        model: 'claude-opus-4-5',
+        usage: { input_tokens: 28_000, output_tokens: 1_200 },
+      });
+      expect(result.contextWindow).toBe(200_000);
+      expect(result.inputBudgetUsed).toBe(28_000);
+      expect(result.utilization).toBeCloseTo(0.14, 4);
+    });
+
+    it('counts cache-creation and cache-read tokens against the input budget', () => {
+      const result = getContextWindowUtilization({
+        model: 'claude-sonnet-4-5',
+        usage: {
+          input_tokens: 28_000,
+          output_tokens: 1_200,
+          cache_creation_input_tokens: 1_800,
+          cache_read_input_tokens: 600,
+        },
+      });
+      expect(result.inputBudgetUsed).toBe(30_400);
+      expect(result.utilization).toBeCloseTo(30_400 / 200_000, 6);
+    });
+
+    it('treats null cache fields the same as absent fields', () => {
+      const result = getContextWindowUtilization({
+        model: 'claude-opus-4-5',
+        usage: {
+          input_tokens: 1_000,
+          cache_creation_input_tokens: null,
+          cache_read_input_tokens: null,
+        },
+      });
+      expect(result.inputBudgetUsed).toBe(1_000);
+    });
+
+    it('clamps utilization to 1 when the input budget exceeds the window', () => {
+      const result = getContextWindowUtilization({
+        model: 'claude-opus-4-5',
+        usage: { input_tokens: 250_000 },
+      });
+      expect(result.utilization).toBe(1);
+    });
+
+    it('throws a model-naming error for unknown models without an override', () => {
+      expect(() =>
+        getContextWindowUtilization({
+          model: 'some-other-model',
+          usage: { input_tokens: 100 },
+        }),
+      ).toThrow(/some-other-model/);
+    });
+
+    it('accepts a contextWindowOverride for unknown models', () => {
+      const result = getContextWindowUtilization({
+        model: 'my-tuned-model',
+        usage: { input_tokens: 25_000 },
+        contextWindowOverride: 100_000,
+      });
+      expect(result.contextWindow).toBe(100_000);
+      expect(result.utilization).toBeCloseTo(0.25, 4);
+    });
+
+    it('rejects a non-positive contextWindowOverride', () => {
+      expect(() =>
+        getContextWindowUtilization({
+          model: 'claude-opus-4-5',
+          usage: { input_tokens: 100 },
+          contextWindowOverride: 0,
+        }),
+      ).toThrow(/Invalid context window/);
+    });
+  });
+
+  describe('DEFAULT_MODEL_CONTEXT_WINDOWS', () => {
+    it('covers the documented Claude 4.x family', () => {
+      for (const model of [
+        'claude-opus-4-5',
+        'claude-opus-4-1',
+        'claude-sonnet-4-5',
+        'claude-haiku-4-5',
+      ]) {
+        expect(DEFAULT_MODEL_CONTEXT_WINDOWS[model]).toBe(200_000);
+      }
+    });
+  });
+});


### PR DESCRIPTION
## Why

Addresses #1064.

The Messages API response exposes \`usage.input_tokens\` but not the model's context window size. To compute under- or over-utilization a caller has to know each model's window out-of-band — the issue describes a real consequence (chunking at 15% utilization for weeks without realizing it).

Anthropic's API itself adding \`usage.context_window\` / \`usage.utilization\` fields is a server-side decision and out of scope for an SDK PR. This PR delivers the same ergonomic surface via a client-side helper.

## What

New module \`src/lib/context-window.ts\`, importable as \`@anthropic-ai/sdk/lib/context-window\`:

\`\`\`ts
import { getContextWindowUtilization } from '@anthropic-ai/sdk/lib/context-window';

const message = await client.messages.create({ ... });
const { contextWindow, utilization, inputBudgetUsed } = getContextWindowUtilization({
  model: message.model,
  usage: message.usage,
});
// → { contextWindow: 200000, utilization: 0.146, inputBudgetUsed: 29200 }
\`\`\`

- Built-in lookup of Claude 4.x + legacy model identifiers → context window.
- Cache-creation and cache-read tokens count against the input budget (both consume input context bytes).
- Utilization clamped to \`[0, 1]\`.
- Per-call \`contextWindowOverride\` and \`modelContextWindows\` extension hooks for tuned / proxied / forthcoming deployments.
- Throws a model-naming error when the identifier isn't in the lookup and no override is supplied — explicit failure over silent miscompute.

## Scope

- Sits entirely in \`src/lib/\` — the manual-patch directory CONTRIBUTING.md identifies as safe from Stainless regenerations.
- No generated files modified; no public API on the client object changes.
- Opt-in: users who don't import the helper see zero behavioural difference.

## Tests

12 unit tests in \`tests/lib/context-window.test.ts\` covering:

- Known-model lookups
- Override precedence (override → caller map → built-in defaults)
- Cache-creation + cache-read counting toward input budget
- Null cache fields treated as 0
- Utilization clamping above 1.0
- Unknown-model error path naming the offending model
- Invalid \`contextWindowOverride\` rejection
- Claude 4.x family coverage

\`yarn test tests/lib/context-window.test.ts\` → 12 passed. \`yarn build\` clean.