### PR TITLE
fix(vertex): strip anthropic-beta header on count_tokens requests

### DIFF
--- a/packages/vertex-sdk/src/client.ts
+++ b/packages/vertex-sdk/src/client.ts
@@ -205,6 +205,7 @@ export class AnthropicVertex extends BaseAnthropic {
       }
     }
 
+    let isCountTokens = false;
     if (
       options &&
       (options.path === '/v1/messages/count_tokens' ||
@@ -221,15 +222,29 @@ export class AnthropicVertex extends BaseAnthropic {
         const prefix = url.pathname.slice(0, url.pathname.length - canonicalPath.length);
         url.pathname = `${prefix}/projects/${this.projectId}/locations/${this.region}/publishers/anthropic/models/count-tokens:rawPredict`;
         url.searchParams.delete('beta');
+        isCountTokens = true;
       }
+    }
+
+    // Request/middleware-set headers win over the OAuth headers, preserving
+    // the ability to override `Authorization` explicitly.
+    const mergedHeaders = buildHeaders([googleAuthHeaders, request.headers]);
+
+    if (isCountTokens) {
+      // Vertex's per-model Anthropic backends roll out new `anthropic-beta`
+      // values on independent schedules (Haiku consistently lags), so any
+      // beta value not yet present on the resolved count-tokens model is
+      // rejected with HTTP 400 — recurring breakage in downstream consumers
+      // (see #1016 and anthropics/claude-code#11154). Count-tokens does
+      // not require any beta-gated capabilities, so strip the header here
+      // rather than chasing per-beta Vertex rollouts.
+      mergedHeaders.values.delete('anthropic-beta');
     }
 
     const adapted = {
       ...request,
       url: url.toString(),
-      // Request/middleware-set headers win over the OAuth headers, preserving
-      // the ability to override `Authorization` explicitly.
-      headers: buildHeaders([googleAuthHeaders, request.headers]).values,
+      headers: mergedHeaders.values,
     } as APIRequest;
     if (parsedBody) {
       adapted.body = JSON.stringify(parsedBody);

--- a/packages/vertex-sdk/tests/client.test.ts
+++ b/packages/vertex-sdk/tests/client.test.ts
@@ -206,6 +206,46 @@ describe('AnthropicVertex', () => {
         'https://us-east5-aiplatform.googleapis.com/v1/projects/test-project/locations/us-east5/publishers/anthropic/models/count-tokens:rawPredict',
       );
     });
+
+    // Regression test for #1016. Vertex's per-model Anthropic backends roll
+    // out new `anthropic-beta` values on independent schedules (Haiku
+    // consistently lags), so a beta value not yet present on the resolved
+    // count-tokens model is rejected with HTTP 400. Token counting needs
+    // no beta-gated capabilities, so the header is dropped on this path.
+    test('strips anthropic-beta header on count_tokens requests', async () => {
+      const client = new AnthropicVertex({
+        region: 'us-east5',
+        projectId: 'test-project',
+        fetch: mockFetch as any,
+        defaultHeaders: { 'anthropic-beta': 'effort-2025-11-24' },
+      });
+
+      await client.messages.countTokens({
+        model: createParams.model,
+        messages: createParams.messages,
+      });
+
+      const [, wireInit] = mockFetch.mock.calls[0];
+      const wireHeaders = new Headers(wireInit.headers);
+      expect(wireHeaders.has('anthropic-beta')).toBe(false);
+    });
+
+    // Guard against accidentally stripping the header from non-count-tokens
+    // requests where beta values legitimately gate capabilities.
+    test('does not strip anthropic-beta header on regular messages requests', async () => {
+      const client = new AnthropicVertex({
+        region: 'us-east5',
+        projectId: 'test-project',
+        fetch: mockFetch as any,
+        defaultHeaders: { 'anthropic-beta': 'effort-2025-11-24' },
+      });
+
+      await client.messages.create(createParams);
+
+      const [, wireInit] = mockFetch.mock.calls[0];
+      const wireHeaders = new Headers(wireInit.headers);
+      expect(wireHeaders.get('anthropic-beta')).toBe('effort-2025-11-24');
+    });
   });
 });
 


### PR DESCRIPTION
## Summary

Vertex's per-model Anthropic backends roll out new `anthropic-beta` values on independent schedules — Haiku consistently lags, and other models intermittently. A `client.messages.countTokens(...)` call that includes any newly-introduced beta value lands on whichever model the resolved count-tokens endpoint backs onto, and is rejected with:

```
HTTP 400 invalid_request_error
Unexpected value(s) \"effort-2025-11-24\" for the \"anthropic-beta\" header.
```

The same call against `claude-opus-4-7@default` or `claude-sonnet-4-6@default` succeeds. Past offending values include `structured-outputs-2025-12-15`, `tool-search-tool-2025-10-19`, `context-1m-2025-08-07`, `redact-thinking-2026-02-12`, and `web-search-2025-03-05`.

The most visible downstream impact is Claude Code, which has had recurring breakage tracked at [anthropics/claude-code#11154](https://github.com/anthropics/claude-code/issues/11154) since November 2025 — every new beta value re-triggers the same root cause.

## Fix

Token counting does not require any beta-gated capabilities, so strip the header on the Vertex count-tokens path rather than chasing each new beta value through Vertex's rollout windows.

[`packages/vertex-sdk/src/client.ts`](packages/vertex-sdk/src/client.ts), `#adaptRequest`:

```diff
+    let isCountTokens = false;
     if (
       options &&
       (options.path === '/v1/messages/count_tokens' ||
         (options.path == '/v1/messages/count_tokens?beta=true' && options.method === 'post'))
     ) {
       const canonicalPath = options.path.split('?')[0]!;
       if (url.pathname.endsWith(canonicalPath)) {
         // ...rewrite path...
+        isCountTokens = true;
       }
     }
+
+    const mergedHeaders = buildHeaders([googleAuthHeaders, request.headers]);
+    if (isCountTokens) {
+      mergedHeaders.values.delete('anthropic-beta');
+    }
-    const adapted = {
-      ...request,
-      url: url.toString(),
-      headers: buildHeaders([googleAuthHeaders, request.headers]).values,
-    } as APIRequest;
+    const adapted = {
+      ...request,
+      url: url.toString(),
+      headers: mergedHeaders.values,
+    } as APIRequest;
```

Regular `messages` requests are untouched — the strip is keyed strictly on the count-tokens path.

## Tests

Two regression tests added in [`packages/vertex-sdk/tests/client.test.ts`](packages/vertex-sdk/tests/client.test.ts):

- **`strips anthropic-beta header on count_tokens requests`** — sets `defaultHeaders: { 'anthropic-beta': 'effort-2025-11-24' }`, calls `countTokens`, asserts the wire `Headers` object has no `anthropic-beta` entry. Fails on `main` (header passes through); passes after the fix.
- **`does not strip anthropic-beta header on regular messages requests`** — same defaultHeaders, calls `messages.create`, asserts the beta value reaches the wire. Guards against the strip widening to other endpoints.

## Test plan

- [x] `jest packages/vertex-sdk/tests/client.test.ts` — 16/16 pass (14 existing + 2 new)
- [x] `./scripts/build` — clean
- [x] `./scripts/lint` — clean (the surfaced warnings are pre-existing pkg.exports complaints unrelated to this change)
- [x] `./scripts/format` — clean
- [x] Verified the new strip test fails on `main` by reverting only the production change

Fixes #1016