### PR TITLE
feat: trace message streams with diagnostics_channel

### DIFF
--- a/src/lib/MessageStream.ts
+++ b/src/lib/MessageStream.ts
@@ -17,6 +17,7 @@ import {
 import { Stream } from '../streaming';
 import { RequestOptions } from '../internal/request-options';
 import type { Logger } from '../client';
+import { getTracingChannel, hasTracingChannelSubscribers } from './diagnostics';
 import { maybeParseMessage, type ParsedMessage } from './parser';
 import { JSON_BUF_PROPERTY, withLazyInput } from '../internal/message-stream-utils';
 
@@ -41,7 +42,15 @@ type MessageStreamEventListeners<ParsedT, Event extends keyof MessageStreamEvent
   once?: boolean;
 }[];
 
+const MESSAGE_STREAM_TRACING_CHANNEL = '@anthropic-ai/sdk:messages.stream';
+
 export type TracksToolInput = ToolUseBlock | ServerToolUseBlock;
+
+type MessageStreamTraceContext<ParsedT> = {
+  model: MessageCreateParams['model'];
+  params: MessageCreateParams;
+  result?: ParsedMessage<ParsedT>;
+};
 
 function tracksToolInput(content: ContentBlock): content is TracksToolInput {
   return content.type === 'tool_use' || content.type === 'server_tool_use';
@@ -191,6 +200,30 @@ export class MessageStream<ParsedT = null> implements AsyncIterable<MessageStrea
     params: MessageCreateParams,
     options?: RequestOptions,
   ): Promise<void> {
+    const tracingChannel = await getTracingChannel<MessageStreamTraceContext<ParsedT>>(
+      MESSAGE_STREAM_TRACING_CHANNEL,
+    );
+    if (hasTracingChannelSubscribers(tracingChannel)) {
+      const context: MessageStreamTraceContext<ParsedT> = {
+        model: params.model,
+        params,
+      };
+      await tracingChannel.tracePromise(async () => {
+        const result = await this.#createMessageStream(messages, params, options);
+        context.result = result;
+        return result;
+      }, context);
+      return;
+    }
+
+    await this.#createMessageStream(messages, params, options);
+  }
+
+  async #createMessageStream(
+    messages: Messages,
+    params: MessageCreateParams,
+    options?: RequestOptions,
+  ): Promise<ParsedMessage<ParsedT>> {
     const signal = options?.signal;
     let abortHandler: (() => void) | undefined;
     if (signal) {
@@ -210,7 +243,7 @@ export class MessageStream<ParsedT = null> implements AsyncIterable<MessageStrea
       if (stream.controller.signal?.aborted) {
         throw new APIUserAbortError();
       }
-      this.#endRequest();
+      return this.#endRequest();
     } finally {
       if (signal && abortHandler) {
         signal.removeEventListener('abort', abortHandler);

--- a/src/lib/diagnostics.ts
+++ b/src/lib/diagnostics.ts
@@ -1,0 +1,80 @@
+export type AnthropicTracingChannel<Context extends object> = {
+  readonly hasSubscribers: boolean;
+  tracePromise<T>(fn: () => Promise<T>, context?: Context): Promise<T>;
+};
+
+type DiagnosticsChannelModule = {
+  tracingChannel?: <Context extends object>(name: string) => AnthropicTracingChannel<Context>;
+};
+
+type ProcessWithBuiltinModule = {
+  getBuiltinModule?: (id: string) => unknown;
+};
+
+type TracingChannelFactory = (name: string) => AnthropicTracingChannel<any> | null;
+
+let diagnosticsChannelModulePromise: Promise<DiagnosticsChannelModule | null> | undefined;
+let tracingChannelFactoryForTesting: TracingChannelFactory | undefined;
+
+function isNodeRuntime(): boolean {
+  const process = (globalThis as any).process;
+  return Object.prototype.toString.call(process ?? 0) === '[object process]';
+}
+
+function loadDiagnosticsChannelSync(): DiagnosticsChannelModule | null {
+  const process = (globalThis as any).process as ProcessWithBuiltinModule | undefined;
+  if (!process?.getBuiltinModule) {
+    return null;
+  }
+
+  try {
+    const module = process.getBuiltinModule('node:diagnostics_channel') as DiagnosticsChannelModule;
+    return typeof module?.tracingChannel === 'function' ? module : null;
+  } catch {
+    return null;
+  }
+}
+
+async function loadDiagnosticsChannel(): Promise<DiagnosticsChannelModule | null> {
+  const syncModule = loadDiagnosticsChannelSync();
+  if (syncModule) {
+    return syncModule;
+  }
+
+  if (!isNodeRuntime()) {
+    return null;
+  }
+
+  try {
+    const module = (await import('node:diagnostics_channel')) as unknown as DiagnosticsChannelModule;
+    return typeof module?.tracingChannel === 'function' ? module : null;
+  } catch {
+    return null;
+  }
+}
+
+export async function getTracingChannel<Context extends object>(
+  name: string,
+): Promise<AnthropicTracingChannel<Context> | null> {
+  if (tracingChannelFactoryForTesting) {
+    return tracingChannelFactoryForTesting(name) as AnthropicTracingChannel<Context> | null;
+  }
+
+  diagnosticsChannelModulePromise ??= loadDiagnosticsChannel();
+  const module = await diagnosticsChannelModulePromise;
+  return module?.tracingChannel?.<Context>(name) ?? null;
+}
+
+export function hasTracingChannelSubscribers<Context extends object>(
+  channel: AnthropicTracingChannel<Context> | null,
+): channel is AnthropicTracingChannel<Context> {
+  return channel?.hasSubscribers === true;
+}
+
+export function setTracingChannelFactoryForTesting(factory: TracingChannelFactory | undefined): () => void {
+  const previous = tracingChannelFactoryForTesting;
+  tracingChannelFactoryForTesting = factory;
+  return () => {
+    tracingChannelFactoryForTesting = previous;
+  };
+}

--- a/tests/api-resources/MessageStream.test.ts
+++ b/tests/api-resources/MessageStream.test.ts
@@ -1,6 +1,7 @@
 import Anthropic, { APIConnectionError, APIUserAbortError } from '@anthropic-ai/sdk';
 import { Message, MessageStreamEvent } from '@anthropic-ai/sdk/resources/messages';
 import * as partialJsonParser from '@anthropic-ai/sdk/_vendor/partial-json-parser/parser';
+import { setTracingChannelFactoryForTesting } from '../../src/lib/diagnostics';
 import { mockFetch } from '../lib/mock-fetch';
 import { loadFixture, parseSSEFixture } from '../lib/sse-helpers';
 
@@ -204,6 +205,64 @@ describe('MessageStream class', () => {
 
     assertBasicResponse(events, finalMessage);
     expect(finalText).toBe('Hello there!');
+  });
+
+  it('traces message streams when diagnostics subscribers exist', async () => {
+    const { fetch, handleStreamEvents } = mockFetch();
+
+    const anthropic = new Anthropic({ apiKey: '...', fetch });
+
+    const fixtureContent = loadFixture('basic_response.txt');
+    const streamEvents = await parseSSEFixture(fixtureContent);
+    handleStreamEvents(streamEvents);
+
+    const traceCalls: Array<{
+      name: string;
+      context: {
+        model?: string;
+        params?: { stream?: boolean; messages?: unknown };
+        result?: unknown;
+      };
+    }> = [];
+    const restoreTracing = setTracingChannelFactoryForTesting((name) => ({
+      hasSubscribers: true,
+      async tracePromise<T>(fn: () => Promise<T>, context?: object): Promise<T> {
+        traceCalls.push({ name, context: context ?? {} });
+        const result = await fn();
+        if (context) {
+          (context as { result?: T }).result = result;
+        }
+        return result;
+      },
+    }));
+
+    try {
+      const stream = anthropic.messages.stream({
+        max_tokens: 1024,
+        model: 'claude-opus-4-20250514',
+        messages: [{ role: 'user', content: 'Say hello there!' }],
+      });
+
+      const events: MessageStreamEvent[] = [];
+      for await (const event of stream) {
+        events.push(event);
+      }
+
+      await stream.done();
+      const finalMessage = await stream.finalMessage();
+
+      assertBasicResponse(events, finalMessage);
+      expect(traceCalls).toHaveLength(1);
+      expect(traceCalls[0]!.name).toBe('@anthropic-ai/sdk:messages.stream');
+      expect(traceCalls[0]!.context.model).toBe('claude-opus-4-20250514');
+      expect(traceCalls[0]!.context.params?.stream).toBe(true);
+      expect(traceCalls[0]!.context.params?.messages).toEqual([
+        { role: 'user', content: 'Say hello there!' },
+      ]);
+      expect(traceCalls[0]!.context.result).toMatchObject(EXPECTED_BASIC_MESSAGE);
+    } finally {
+      restoreTracing();
+    }
   });
 
   it('handles tool use response fixture', async () => {


### PR DESCRIPTION
Adds a first observability slice for #1036 by tracing
`anthropic.messages.stream(...)` through Node's `diagnostics_channel`
`TracingChannel`.

This intentionally covers only `@anthropic-ai/sdk:messages.stream`.
`messages.create` and `completions.create` still return lazy `APIPromise`
objects, where tracing needs a separate design so `.asResponse()` callers do not
start parsing response bodies unexpectedly.

Implementation notes:

- add an internal diagnostics helper that lazily loads
  `node:diagnostics_channel` and returns `null` on unsupported runtimes;
- only allocate stream trace context when the channel has subscribers;
- wrap the full `MessageStream` request/stream lifecycle in `tracePromise()`;
- expose the final parsed message as `context.result` on success;
- add MessageStream coverage for channel name, params, and final result.

Validation:

- `./node_modules/.bin/jest tests/api-resources/MessageStream.test.ts --runInBand`
- `./node_modules/.bin/tsc --noEmit`
- `./node_modules/.bin/prettier --check src/lib/diagnostics.ts src/lib/MessageStream.ts tests/api-resources/MessageStream.test.ts`
- `git diff --check -- src/lib/MessageStream.ts tests/api-resources/MessageStream.test.ts`
- `git diff --check HEAD~1..HEAD -- src/lib/MessageStream.ts src/lib/diagnostics.ts tests/api-resources/MessageStream.test.ts`
- `./scripts/build`

Addresses #1036.
