### PR TITLE
perf(streaming): drain SSE buffer in linear time

### DIFF
--- a/src/core/streaming.ts
+++ b/src/core/streaming.ts
@@ -323,11 +323,13 @@ async function* iterSSEChunks(iterator: AsyncIterableIterator<Bytes>): AsyncGene
     newData.set(binaryChunk, data.length);
     data = newData;
 
+    let offset = 0;
     let patternIndex;
-    while ((patternIndex = findDoubleNewlineIndex(data)) !== -1) {
-      yield data.slice(0, patternIndex);
-      data = data.slice(patternIndex);
+    while ((patternIndex = findDoubleNewlineIndex(data, offset)) !== -1) {
+      yield data.slice(offset, patternIndex);
+      offset = patternIndex;
     }
+    if (offset > 0) data = data.slice(offset);
   }
 
   if (data.length > 0) {

--- a/src/internal/decoders/line.ts
+++ b/src/internal/decoders/line.ts
@@ -103,14 +103,14 @@ function findNewlineIndex(
   return null;
 }
 
-export function findDoubleNewlineIndex(buffer: Uint8Array): number {
+export function findDoubleNewlineIndex(buffer: Uint8Array, start: number = 0): number {
   // This function searches the buffer for the end patterns (\r\r, \n\n, \r\n\r\n)
   // and returns the index right after the first occurrence of any pattern,
   // or -1 if none of the patterns are found.
   const newline = 0x0a; // \n
   const carriage = 0x0d; // \r
 
-  for (let i = 0; i < buffer.length - 1; i++) {
+  for (let i = start; i < buffer.length - 1; i++) {
     if (buffer[i] === newline && buffer[i + 1] === newline) {
       // \n\n
       return i + 2;

--- a/tests/streaming.test.ts
+++ b/tests/streaming.test.ts
@@ -217,6 +217,81 @@ describe('streaming decoding', () => {
     event = await stream.next();
     expect(event.done).toBeTruthy();
   });
+
+  test('decodes many events delivered in a single chunk, in order', async () => {
+    const N = 2000;
+    let payload = '';
+    for (let i = 0; i < N; i++) payload += `event: completion\ndata: {"i":${i}}\n\n`;
+    async function* body(): AsyncGenerator<Buffer> {
+      yield Buffer.from(payload); // entire response arrives as one transport chunk
+    }
+
+    const stream = _iterSSEMessages(new Response(ReadableStreamFrom(body())), new AbortController())[
+      Symbol.asyncIterator
+    ]();
+
+    let count = 0;
+    for (let result = await stream.next(); !result.done; result = await stream.next()) {
+      expect(JSON.parse(result.value.data)).toEqual({ i: count });
+      count++;
+    }
+    expect(count).toBe(N);
+  });
+
+  test('decodes events when boundaries are split across chunks', async () => {
+    const N = 60;
+    let payload = '';
+    for (let i = 0; i < N; i++) payload += `event: completion\ndata: {"i":${i}}\n\n`;
+    const bytes = Buffer.from(payload);
+    async function* body(): AsyncGenerator<Buffer> {
+      // 3-byte chunks force every "\n\n" boundary to straddle a chunk edge
+      for (let offset = 0; offset < bytes.length; offset += 3) {
+        yield bytes.subarray(offset, offset + 3);
+      }
+    }
+
+    const stream = _iterSSEMessages(new Response(ReadableStreamFrom(body())), new AbortController())[
+      Symbol.asyncIterator
+    ]();
+
+    let count = 0;
+    for (let result = await stream.next(); !result.done; result = await stream.next()) {
+      expect(JSON.parse(result.value.data)).toEqual({ i: count });
+      count++;
+    }
+    expect(count).toBe(N);
+  });
+
+  test('drains a multi-event chunk in linear time (no O(n^2) re-slicing)', async () => {
+    const N = 2000;
+    let payload = '';
+    for (let i = 0; i < N; i++) payload += `event: completion\ndata: {"i":${i}}\n\n`;
+    const totalBytes = Buffer.byteLength(payload);
+    async function* body(): AsyncGenerator<Buffer> {
+      yield Buffer.from(payload);
+    }
+
+    // Count bytes copied via Uint8Array.prototype.slice while draining. The previous
+    // implementation re-sliced the whole remaining buffer once per event (~N/2 * totalBytes
+    // total); the offset-cursor implementation copies each event once (~totalBytes total).
+    const realSlice = Uint8Array.prototype.slice;
+    let bytesCopied = 0;
+    (Uint8Array.prototype as any).slice = function (this: Uint8Array, start?: number, end?: number) {
+      bytesCopied += Math.max(0, (end ?? this.length) - (start ?? 0));
+      return realSlice.call(this, start as any, end as any);
+    };
+    try {
+      const stream = _iterSSEMessages(new Response(ReadableStreamFrom(body())), new AbortController())[
+        Symbol.asyncIterator
+      ]();
+      let count = 0;
+      for (let result = await stream.next(); !result.done; result = await stream.next()) count++;
+      expect(count).toBe(N);
+    } finally {
+      Uint8Array.prototype.slice = realSlice;
+    }
+    expect(bytesCopied).toBeLessThan(totalBytes * 8);
+  });
 });
 
 test('error handling', async () => {


### PR DESCRIPTION
## Summary

`iterSSEChunks` (`src/core/streaming.ts`) drains each transport chunk like this:

```ts
while ((patternIndex = findDoubleNewlineIndex(data)) !== -1) {
  yield data.slice(0, patternIndex);
  data = data.slice(patternIndex);   // copies the ENTIRE remaining buffer, per event
}
```

When one transport read delivers M SSE events (total length L), the
`data = data.slice(patternIndex)` line copies the whole remaining buffer once per
event: `L + (L-e1) + (L-e1-e2) + ... = O(M·L)`. Across a long stream that is
O(N²) in the number of events whenever the network hands us multiple events per
read, which is the common case for fast token streams and any buffered or
replayed response.

This is independent of message accumulation: it bites even a consumer that just
does `for await (const event of stream) {}` and never touches a snapshot.

## Fix

Scan each chunk with an integer offset cursor and compact the buffer once per
chunk instead of once per event. `findDoubleNewlineIndex` gains a
backward-compatible `start` argument, mirroring the existing `startIndex`
argument on `findNewlineIndex` in the same file. Yielded output is byte-identical.

## Benchmark

Streaming N text deltas through a real `messages.stream()` over a mock transport,
median of 3 runs, Node 22:

| events | before | after |
|---|---|---|
| 16,000 | 3,537 ms (scales 8.4× for 4× input → quadratic) | 217 ms (2.8× → linear) |
| 40,000 | ~19,000 ms (12.3×) | 471 ms (4.1×) |

The absolute speedup depends on how many events the transport buffers per read:
large when a read carries many events (fast streams, buffered responses),
negligible when the transport delivers one event per read. The complexity change
from O(N²) to O(N) holds either way.

## Tests

Added to `tests/streaming.test.ts`:
- many events delivered in a single chunk decode in order,
- event boundaries split across chunks (including `\n\n` straddling a chunk edge) decode correctly,
- a guard asserting a multi-event chunk is drained with a linear number of byte copies (this fails against the old per-event re-slicing, which copies ~1000× more).

All existing streaming and decoder tests pass; `tsc --noEmit` and prettier are clean.

## Relationship to #933 and #995

Both issues report O(N²) in streaming. #933 (eager `partialParse` per
`input_json_delta`) is already fixed on `main` by the lazy `withLazyInput` getter.
The remaining real, transport-level O(N²) is this one.

There is also a separate O(N²) that only affects consumers which re-materialize
the full accumulated `.text` / `.thinking` snapshot on every delta (progressive
UIs reading the second arg of the `text` event). That one is consumer-side and
would need an event-signature change, so it is out of scope here.

Refs #995, #933.
