### PR TITLE
fix: honor request timeout for long non-streaming messages

### DIFF
--- a/src/resources/beta/messages/messages.ts
+++ b/src/resources/beta/messages/messages.ts
@@ -131,7 +131,7 @@ export class Messages extends APIResource {
       );
     }
 
-    let timeout = (this._client as any)._options.timeout as number | null;
+    let timeout = options?.timeout ?? ((this._client as any)._options.timeout as number | null);
     if (!body.stream && timeout == null) {
       const maxNonstreamingTokens = MODEL_NONSTREAMING_TOKENS[body.model] ?? undefined;
       timeout = this._client.calculateNonstreamingTimeout(body.max_tokens, maxNonstreamingTokens);

--- a/src/resources/messages/messages.ts
+++ b/src/resources/messages/messages.ts
@@ -85,7 +85,7 @@ export class Messages extends APIResource {
       );
     }
 
-    let timeout = (this._client as any)._options.timeout as number | null;
+    let timeout = options?.timeout ?? ((this._client as any)._options.timeout as number | null);
     if (!body.stream && timeout == null) {
       const maxNonstreamingTokens = MODEL_NONSTREAMING_TOKENS[body.model] ?? undefined;
       timeout = this._client.calculateNonstreamingTimeout(body.max_tokens, maxNonstreamingTokens);

--- a/tests/resources/beta/messages/parse.test.ts
+++ b/tests/resources/beta/messages/parse.test.ts
@@ -19,6 +19,27 @@ const messages = new Messages(mockClient);
 describe('Messages.parse()', () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    mockClient._options.timeout = null;
+    mockClient.calculateNonstreamingTimeout.mockReturnValue(600000);
+  });
+
+  it('honors request-level timeout when checking long non-streaming requests', () => {
+    messages.create(
+      {
+        model: 'claude-3-5-sonnet-latest',
+        max_tokens: 100000,
+        messages: [{ role: 'user', content: 'Hello' }],
+      },
+      { timeout: 1200000 },
+    );
+
+    expect(mockClient.calculateNonstreamingTimeout).not.toHaveBeenCalled();
+    expect(mockPost).toHaveBeenCalledWith(
+      '/v1/messages?beta=true',
+      expect.objectContaining({
+        timeout: 1200000,
+      }),
+    );
   });
 
   it('parses structured output correctly', async () => {

--- a/tests/resources/messages/parse.test.ts
+++ b/tests/resources/messages/parse.test.ts
@@ -18,6 +18,27 @@ const messages = new Messages(mockClient);
 describe('Messages.parse()', () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    mockClient._options.timeout = null;
+    mockClient.calculateNonstreamingTimeout.mockReturnValue(600000);
+  });
+
+  it('honors request-level timeout when checking long non-streaming requests', () => {
+    messages.create(
+      {
+        model: 'claude-3-5-sonnet-latest',
+        max_tokens: 100000,
+        messages: [{ role: 'user', content: 'Hello' }],
+      },
+      { timeout: 1200000 },
+    );
+
+    expect(mockClient.calculateNonstreamingTimeout).not.toHaveBeenCalled();
+    expect(mockPost).toHaveBeenCalledWith(
+      '/v1/messages',
+      expect.objectContaining({
+        timeout: 1200000,
+      }),
+    );
   });
 
   it('parses structured output correctly', async () => {


### PR DESCRIPTION
## Summary
Honor request-level `timeout` options before calculating long non-streaming message timeouts.

## Motivation
Passing a client-level timeout suppresses the long non-streaming request timeout calculation, but passing the same timeout per request currently does not. This causes a long-request error even when callers explicitly provide a request-level timeout.

Fixes #1097

## Changes
- Prefer `options.timeout` before falling back to the client-level timeout in stable messages.
- Apply the same behavior to beta messages.
- Add stable and beta tests asserting request-level timeout bypasses `calculateNonstreamingTimeout` and is passed to `post()`.

## Testing
- `yarn install --frozen-lockfile --ignore-scripts`
- `./node_modules/.bin/jest tests/resources/messages/parse.test.ts tests/resources/beta/messages/parse.test.ts --runInBand` → `2 suites passed, 8 tests passed`
- `yarn lint` passed
- `git diff --check`
- Secret scan on diff: clean