### PR TITLE
fix(aws): preserve AWS options on withOptions() clones so environment helpers work on Claude Platform on AWS

### DIFF
--- a/packages/aws-sdk/src/client.ts
+++ b/packages/aws-sdk/src/client.ts
@@ -217,6 +217,27 @@ export class AnthropicAws extends Anthropic {
     this.skipAuth = skipAuth;
     this._useSigV4 = resolvedApiKey == null;
 
+    // The base constructor only records the options it received (`apiKey`,
+    // `baseURL`, `...opts`) on `this._options`, which is what `withOptions()`
+    // spreads when it rebuilds a clone. The AWS-specific options above were
+    // destructured out before `super()`, so without this a clone (used by the
+    // environment poller / worker / session-tool-runner, and by any direct
+    // `withOptions()` call) would be reconstructed without them — throwing
+    // "No workspace ID found" and dropping the AWS credentials. Re-record them
+    // so clones round-trip the full AWS configuration.
+    const awsOptions: AwsClientOptions = {
+      ...this._options,
+      awsRegion,
+      awsAccessKey,
+      awsSecretAccessKey,
+      awsSessionToken,
+      awsProfile,
+      providerChainResolver,
+      workspaceId: resolvedWorkspaceId,
+      skipAuth,
+    };
+    this._options = awsOptions;
+
     if (syncRegion || explicitBaseURL || skipAuth) {
       this.ready = Promise.resolve();
     } else {

--- a/packages/aws-sdk/tests/client.test.ts
+++ b/packages/aws-sdk/tests/client.test.ts
@@ -809,4 +809,64 @@ describe('AnthropicAws', () => {
       expect(client.models).toBeDefined();
     });
   });
+
+  describe('withOptions', () => {
+    test('clone preserves AWS SigV4 configuration', () => {
+      const client = new AnthropicAws({
+        awsAccessKey: 'my-access-key',
+        awsSecretAccessKey: 'my-secret-key',
+        awsSessionToken: 'my-session-token',
+        awsRegion: 'us-west-2',
+        workspaceId: 'ws-test',
+      });
+
+      const clone = client.withOptions({ defaultHeaders: { 'x-custom': '1' } });
+
+      expect(clone).toBeInstanceOf(AnthropicAws);
+      expect(clone.workspaceId).toBe('ws-test');
+      expect(clone.awsRegion).toBe('us-west-2');
+      expect(clone.awsAccessKey).toBe('my-access-key');
+      expect(clone.awsSecretAccessKey).toBe('my-secret-key');
+      expect(clone.awsSessionToken).toBe('my-session-token');
+    });
+
+    test('clone preserves API-key configuration', () => {
+      const client = new AnthropicAws({
+        apiKey: 'my-api-key',
+        awsRegion: 'us-east-1',
+        workspaceId: 'ws-test',
+      });
+
+      const clone = client.withOptions({ maxRetries: 5 });
+
+      expect(clone).toBeInstanceOf(AnthropicAws);
+      expect(clone.workspaceId).toBe('ws-test');
+      expect(clone.awsRegion).toBe('us-east-1');
+      expect(clone.maxRetries).toBe(5);
+    });
+
+    test('auth-override clone (as used by the environment work helpers) preserves workspace + region', () => {
+      // Mirrors copyClientForHelper: it calls withOptions({ apiKey: null,
+      // authToken, credentials: undefined, ... }) to scope a sub-client. On the
+      // AWS client the sub-client must still carry the workspace id + region so
+      // the poller / worker / session-tool-runner can authenticate via SigV4.
+      const client = new AnthropicAws({
+        awsAccessKey: 'my-access-key',
+        awsSecretAccessKey: 'my-secret-key',
+        awsRegion: 'us-west-2',
+        workspaceId: 'ws-test',
+      });
+
+      const scoped = client.withOptions({
+        apiKey: null,
+        authToken: 'unused-under-sigv4',
+        credentials: undefined,
+        baseURL: client.baseURL,
+      });
+
+      expect(scoped).toBeInstanceOf(AnthropicAws);
+      expect(scoped.workspaceId).toBe('ws-test');
+      expect(scoped.awsRegion).toBe('us-west-2');
+    });
+  });
 });


### PR DESCRIPTION
Fixes #1109.

### Problem

`AnthropicAws.withOptions()` produces a broken clone — it throws `No workspace ID found` (or silently drops the AWS credentials). The self-hosted environment helpers (`client.beta.environments.work.poller()`, `EnvironmentWorker`, `SessionToolRunner`) all scope a sub-client via `copyClientForHelper` → `withOptions({ apiKey: null, authToken, credentials: undefined, ... })`, so this makes the environment poller/worker unusable on Claude Platform on AWS. Direct `withOptions()` calls are affected too.

Reproduced on the latest published packages (`@anthropic-ai/aws-sdk@0.6.0` / `@anthropic-ai/sdk@0.110.0`). Full repro in #1109.

### Root cause

The `AnthropicAws` constructor destructures the AWS-specific options as named params and forwards only `...opts` to `super()`. The base client records just what it received on `this._options`, and `withOptions()` rebuilds a clone by spreading `...this._options` back through the constructor — so the clone loses `workspaceId`, `awsRegion`, and the AWS credentials (`'workspaceId' in client._options === false`).

### Fix

Re-record the AWS-specific options on `this._options` after `super()`, so `withOptions()` (and any clone) round-trips the full AWS configuration. Confined to `packages/aws-sdk/src/client.ts`.

### Tests

Added a `withOptions` describe block to `packages/aws-sdk/tests/client.test.ts`:
- plain SigV4 clone preserves workspace id / region / credentials,
- API-key clone preserves workspace id / region,
- the auth-override clone the environment work helpers build preserves workspace id / region.

All three fail without the fix and pass with it. Full `packages/aws-sdk` suite passes (64 tests); `scripts/lint` passes ("Types ok!"); formatter clean.

### Real-world validation

Validated end-to-end using Amazon EKS as the self-hosted environment, with the poller/worker authenticating to Claude Platform on AWS via EKS Pod Identity (SigV4). With the fix, `poller()` scopes its sub-client and polls the work queue successfully instead of throwing on the first iteration.

### Related

TypeScript analogue of the Python SDK fix anthropics/anthropic-sdk-python#1737 (issue #1736).
