### PR TITLE
Remove unsupported idempotency request option

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -2,7 +2,6 @@
 
 import type { RequestInit, RequestInfo, BodyInit } from './internal/builtin-types';
 import type { HTTPMethod, PromiseOrValue, MergedRequestInit, FinalizedRequestInit } from './internal/types';
-import { uuid4 } from './internal/utils/uuid';
 import { validatePositiveInteger, isAbsoluteURL, safeJSON } from './internal/utils/values';
 import { sleep } from './internal/utils/sleep';
 export type { Logger, LogLevel } from './internal/utils/log';
@@ -487,7 +486,6 @@ export class BaseAnthropic {
 
   private fetch: Fetch;
   #encoder: Opts.RequestEncoder;
-  protected idempotencyHeader?: string;
   protected _options: ClientOptions;
 
   /**
@@ -846,10 +844,6 @@ export class BaseAnthropic {
 
   private getUserAgent(): string {
     return `${this.constructor.name}/JS ${VERSION}`;
-  }
-
-  protected defaultIdempotencyKey(): string {
-    return `stainless-node-retry-${uuid4()}`;
   }
 
   protected makeStatusError(
@@ -1427,7 +1421,7 @@ export class BaseAnthropic {
     if ('timeout' in options) validatePositiveInteger('timeout', options.timeout);
     options.timeout = options.timeout ?? this.timeout;
     const { bodyHeaders, body } = this.buildBody({ options });
-    const reqHeaders = await this.buildHeaders({ options: inputOptions, method, bodyHeaders, retryCount });
+    const reqHeaders = await this.buildHeaders({ options: inputOptions, bodyHeaders, retryCount });
 
     const req: FinalizedRequestInit = {
       method,
@@ -1445,23 +1439,14 @@ export class BaseAnthropic {
 
   private async buildHeaders({
     options,
-    method,
     bodyHeaders,
     retryCount,
   }: {
     options: FinalRequestOptions;
-    method: HTTPMethod;
     bodyHeaders: HeadersLike;
     retryCount: number;
   }): Promise<Headers> {
-    let idempotencyHeaders: HeadersLike = {};
-    if (this.idempotencyHeader && method !== 'get') {
-      if (!options.idempotencyKey) options.idempotencyKey = this.defaultIdempotencyKey();
-      idempotencyHeaders[this.idempotencyHeader] = options.idempotencyKey;
-    }
-
     const headers = buildHeaders([
-      idempotencyHeaders,
       {
         Accept: 'application/json',
         'User-Agent': this.getUserAgent(),

--- a/src/internal/request-options.ts
+++ b/src/internal/request-options.ts
@@ -120,11 +120,6 @@ export interface RequestOptions {
   fallbackState?: BetaFallbackState;
 
   /**
-   * A unique key for this request to enable idempotency.
-   */
-  idempotencyKey?: string;
-
-  /**
    * Override the default base URL for this specific request.
    */
   defaultBaseURL?: string | undefined;

--- a/tests/request-options.test.ts
+++ b/tests/request-options.test.ts
@@ -1,0 +1,15 @@
+import type { RequestOptions } from '@anthropic-ai/sdk/internal/request-options';
+import { compareType } from './utils/typing';
+
+describe('RequestOptions', () => {
+  test('does not expose unsupported idempotency keys', () => {
+    compareType<'idempotencyKey' extends keyof RequestOptions ? true : false, false>(true);
+
+    const options: RequestOptions = {};
+    expect(options).toEqual({});
+
+    // @ts-expect-error idempotency keys are not supported by the Anthropic API client.
+    const unsupported: RequestOptions = { idempotencyKey: 'retry-key' };
+    expect(unsupported).toEqual({ idempotencyKey: 'retry-key' });
+  });
+});


### PR DESCRIPTION
## Summary

Fixes #1112.

This removes the unsupported `idempotencyKey` request option from the TypeScript SDK surface and deletes the dormant client-side idempotency-header plumbing that depended on an unset `idempotencyHeader`.

I did not add an idempotency header because I could not find an authoritative Anthropic API idempotency header in this repo, the public docs, or the sibling SDKs. Keeping the option in `RequestOptions` makes TypeScript users think the SDK can provide an idempotency guarantee that the client does not actually send.

## Changes

- remove `RequestOptions.idempotencyKey`
- remove the unused `BaseAnthropic.idempotencyHeader` hook
- remove `defaultIdempotencyKey()` and the inactive `buildHeaders` branch
- add a type regression test that `RequestOptions` does not expose `idempotencyKey`

## Validation

- `./node_modules/.bin/jest tests/request-options.test.ts --runInBand`
- `./node_modules/typescript/bin/tsc`
- `./node_modules/.bin/prettier --check src/client.ts src/internal/request-options.ts tests/request-options.test.ts`
- `./node_modules/.bin/eslint src/client.ts src/internal/request-options.ts tests/request-options.test.ts`
- `./scripts/build`
- `./scripts/lint`
- `./node_modules/.bin/jest tests/index.test.ts tests/request-options.test.ts --runInBand`

`./scripts/lint` passed; `publint` emitted the existing package export warnings while exiting successfully.
