### PR TITLE
Pin remaining workflow actions by SHA

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -26,13 +26,13 @@ jobs:
       actions: read # Required for Claude to read CI results on PRs
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           fetch-depth: 1
 
       - name: Run Claude Code
         id: claude
-        uses: anthropics/claude-code-action@v1
+        uses: anthropics/claude-code-action@c937a0c2211f77cbc101b590fb5bdbbdbc263c08 # v1
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
 

--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -21,7 +21,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Set up Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: '20'
 


### PR DESCRIPTION
## Summary
- pin the Claude workflow checkout action to an immutable SHA
- pin the Claude Code action to an immutable SHA
- pin the publish workflow setup-node action to an immutable SHA

This matches the existing workflow pattern where most actions are already SHA-pinned.

## Validation
- python3 -c 'import yaml; yaml.safe_load(open(".github/workflows/claude.yml")); yaml.safe_load(open(".github/workflows/publish-npm.yml")); print("workflow YAML OK")'
- git diff --check
- rg -n "uses: .+@(v[0-9]+|main|master)$" .github/workflows