### PR TITLE
Preserve const and enum in transformed JSON schemas

### DIFF
--- a/src/lib/transform-json-schema.ts
+++ b/src/lib/transform-json-schema.ts
@@ -71,6 +71,16 @@ function _transformJSONSchema(jsonSchema: JSONSchema): JSONSchema {
     strictSchema['title'] = title;
   }
 
+  const constValue = pop(jsonSchema, 'const');
+  if (constValue !== undefined) {
+    strictSchema['const'] = constValue;
+  }
+
+  const enumValues = pop(jsonSchema, 'enum');
+  if (enumValues !== undefined) {
+    strictSchema['enum'] = enumValues;
+  }
+
   if (type === 'object') {
     const properties = pop(jsonSchema, 'properties') || {};
 

--- a/tests/helpers/transform-json-schema.test.ts
+++ b/tests/helpers/transform-json-schema.test.ts
@@ -324,6 +324,56 @@ describe('transformJsonSchema', () => {
 `);
   });
 
+  it('should preserve const and enum constraints', () => {
+    const input = {
+      type: 'object',
+      properties: {
+        change: {
+          anyOf: [
+            {
+              type: 'object',
+              properties: {
+                action: {
+                  type: 'string',
+                  const: 'set_title',
+                },
+                title: {
+                  type: 'string',
+                },
+              },
+              required: ['action', 'title'],
+            },
+            {
+              type: 'object',
+              properties: {
+                action: {
+                  type: 'string',
+                  enum: ['add_members', 'remove_members'],
+                },
+                emails: {
+                  type: 'array',
+                  items: { type: 'string' },
+                },
+              },
+              required: ['action', 'emails'],
+            },
+          ],
+        },
+      },
+    };
+
+    const result = transformJSONSchema(input);
+
+    expect(result['properties']['change']['anyOf'][0]['properties']['action']).toEqual({
+      type: 'string',
+      const: 'set_title',
+    });
+    expect(result['properties']['change']['anyOf'][1]['properties']['action']).toEqual({
+      type: 'string',
+      enum: ['add_members', 'remove_members'],
+    });
+  });
+
   it('should remove unsupported string formats', () => {
     const input = {
       type: 'object',

--- a/tests/helpers/zod.test.ts
+++ b/tests/helpers/zod.test.ts
@@ -32,6 +32,30 @@ describe('beta zod helpers', () => {
       expect(format.schema).toBeDefined();
     });
 
+    it('preserves discriminated union constraints in JSON schema', () => {
+      const schema = z.object({
+        change: z.discriminatedUnion('action', [
+          z.object({ action: z.literal('set_title'), title: z.string() }),
+          z.object({
+            action: z.enum(['add_members', 'remove_members']),
+            emails: z.array(z.string()),
+          }),
+        ]),
+      });
+
+      const format = betaZodOutputFormat(schema);
+      const changeSchema = (format.schema as any).properties.change;
+
+      expect(changeSchema.anyOf[0].properties.action).toEqual({
+        type: 'string',
+        const: 'set_title',
+      });
+      expect(changeSchema.anyOf[1].properties.action).toEqual({
+        type: 'string',
+        enum: ['add_members', 'remove_members'],
+      });
+    });
+
     it('parses valid JSON correctly', () => {
       const schema = z.object({
         city: z.string(),


### PR DESCRIPTION
## Summary

- Preserve `const` and `enum` when `transformJSONSchema()` builds strict JSON schemas.
- Add a regression test for a discriminated-union-shaped schema so literal discriminants stay as real schema constraints.
- Add beta Zod output-format coverage to ensure Zod discriminated unions keep their branch selectors in the generated JSON schema.

## Why this matters

The previous transform treated unknown JSON Schema keywords as prose and appended them to `description`. For discriminated unions, that meant literal branch selectors such as `{ const: "set_title" }` or enum choices could be demoted from machine-readable constraints to description text.

Keeping these constraints in the schema makes the helper output more faithful to the original Zod/JSON Schema and gives models a real branch discriminator instead of relying on prose.

Addresses #1116.

## Validation

- `./node_modules/.bin/jest tests/helpers/transform-json-schema.test.ts tests/helpers/zod.test.ts`
- `./node_modules/.bin/prettier --check src/lib/transform-json-schema.ts tests/helpers/transform-json-schema.test.ts tests/helpers/zod.test.ts`
- `./node_modules/.bin/eslint src/lib/transform-json-schema.ts tests/helpers/transform-json-schema.test.ts tests/helpers/zod.test.ts`
- `./node_modules/typescript/bin/tsc --noEmit`
