### PR TITLE
fix: infer MIME type from Blob and Blob-like objects in toFile function

### DIFF
--- a/src/internal/to-file.ts
+++ b/src/internal/to-file.ts
@@ -3,6 +3,7 @@ import type { FilePropertyBag } from './builtin-types';
 import { checkFileSupport } from './uploads';
 
 type BlobLikePart = string | ArrayBuffer | ArrayBufferView | BlobLike | DataView;
+type BytesResult = { parts: Array<BlobPart>; type?: string };
 
 /**
  * Intended to match DOM Blob, node-fetch Blob, node:buffer Blob, etc.
@@ -109,23 +110,26 @@ export async function toFile(
     const blob = await value.blob();
     name ||= new URL(value.url).pathname.split(/[\\/]/).pop();
 
-    return makeFile(await getBytes(blob), name, options);
-  }
-
-  const parts = await getBytes(value);
-
-  if (!options?.type) {
-    const type = parts.find((part) => typeof part === 'object' && 'type' in part && part.type);
-    if (typeof type === 'string') {
-      options = { ...options, type };
+    const bytes = await getBytes(blob);
+    if (!options?.type && bytes.type) {
+      options = { ...options, type: bytes.type };
     }
+
+    return makeFile(bytes.parts, name, options);
   }
 
-  return makeFile(parts, name, options);
+  const bytes = await getBytes(value);
+
+  if (!options?.type && bytes.type) {
+    options = { ...options, type: bytes.type };
+  }
+
+  return makeFile(bytes.parts, name, options);
 }
 
-async function getBytes(value: BlobLikePart | AsyncIterable<BlobLikePart>): Promise<Array<BlobPart>> {
+async function getBytes(value: BlobLikePart | AsyncIterable<BlobLikePart>): Promise<BytesResult> {
   let parts: Array<BlobPart> = [];
+  let type: string | undefined;
   if (
     typeof value === 'string' ||
     ArrayBuffer.isView(value) || // includes Uint8Array, Buffer, etc.
@@ -134,11 +138,14 @@ async function getBytes(value: BlobLikePart | AsyncIterable<BlobLikePart>): Prom
     parts.push(value);
   } else if (isBlobLike(value)) {
     parts.push(value instanceof Blob ? value : await value.arrayBuffer());
+    type = value.type || undefined;
   } else if (
     isAsyncIterable(value) // includes Readable, ReadableStream, etc.
   ) {
     for await (const chunk of value) {
-      parts.push(...(await getBytes(chunk as BlobLikePart))); // TODO, consider validating?
+      const chunkBytes = await getBytes(chunk as BlobLikePart); // TODO, consider validating?
+      parts.push(...chunkBytes.parts);
+      type ||= chunkBytes.type;
     }
   } else {
     const constructor = value?.constructor?.name;
@@ -149,7 +156,7 @@ async function getBytes(value: BlobLikePart | AsyncIterable<BlobLikePart>): Prom
     );
   }
 
-  return parts;
+  return type ? { parts, type } : { parts };
 }
 
 function propsForError(value: unknown): string {

--- a/tests/uploads.test.ts
+++ b/tests/uploads.test.ts
@@ -49,6 +49,28 @@ describe('toFile', () => {
     expect(file.name).toEqual('input.jsonl');
   });
 
+  it('infers the MIME type from a Blob', async () => {
+    const input = new Blob(['foo'], { type: 'text/plain' });
+    const file = await toFile(input, 'input.txt');
+    expect(file.name).toEqual('input.txt');
+    expect(file.type).toEqual('text/plain');
+  });
+
+  it('infers the MIME type from a Blob-like object', async () => {
+    const input = {
+      size: 3,
+      type: 'text/plain',
+      text: async () => 'foo',
+      slice: () => input,
+      arrayBuffer: async () => new TextEncoder().encode('foo').buffer,
+    };
+
+    const file = await toFile(input, 'input.txt');
+    expect(file.name).toEqual('input.txt');
+    expect(file.type).toEqual('text/plain');
+    await expect(file.text()).resolves.toEqual('foo');
+  });
+
   it('extracts a file name from a ReadStream', async () => {
     const input = fs.createReadStream('tests/uploads.test.ts');
     const file = await toFile(input);


### PR DESCRIPTION
## Problem

The logic in `toFile` that attempts to infer a MIME type from the input content does not actually take effect:

```ts
const type = parts.find((part) => typeof part === 'object' && 'type' in part && part.type);
if (typeof type === 'string') {
  options = { ...options, type };
}
```

`find` returns the matching object itself, not the object's `type` property. Since the predicate only matches object parts, `typeof type === 'string'` is never true, so the MIME type is not inferred.

Even after fixing that check, non-native Blob-like objects can be converted to `ArrayBuffer` inside `getBytes`. Once that conversion happens, the original object's `type` is no longer reachable, so scanning `parts` afterwards cannot recover it.

## Fix

Changed `getBytes`'s return type from `Array<BlobPart>` to `{ parts: Array<BlobPart>; type?: string }`, capturing `type` before the content is converted and propagating it explicitly instead of trying to infer it from `parts` afterwards.

This preserves the existing behavior that an explicitly passed `options.type` takes precedence.

## Tests

Added coverage for:

- Inferring MIME type from a native `Blob`
- Inferring MIME type from a Blob-like object whose content is converted to `ArrayBuffer`

```
corepack yarn jest tests/uploads.test.ts
```

```
 PASS  tests/uploads.test.ts
  toFile
    √ throws a helpful error for mismatched types (4 ms)
    √ disallows string at the type-level (1 ms)
    √ extracts a file name from a Response
    √ extracts a file name from a File
    √ infers the MIME type from a Blob
    √ infers the MIME type from a Blob-like object (1 ms)
    √ extracts a file name from a ReadStream (3 ms)
    √ allows overriding props from a ReadStream (2 ms)
    √ does not copy File objects by default (1 ms)
    √ allows overriding props from a File (1 ms)
    √ is assignable to File and Blob
  missing File error message
    √ is thrown (4 ms)

Test Suites: 1 passed, 1 total
Tests:       12 passed, 12 total
Snapshots:   3 passed, 3 total
Time:        1.135 s
```