### PR TITLE
fix(client): release abort listeners when requests settle

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -1205,7 +1205,7 @@ export class BaseAnthropic {
       }),
     );
 
-    armAbandonmentBackstop(response, controller);
+    armAbandonmentBackstop(response.body ?? response, controller);
     return { response, options, controller, requestLogID, retryOfRequestLogID, startTime };
   }
 
@@ -1251,7 +1251,7 @@ export class BaseAnthropic {
     const abort = this._makeAbort(controller);
     if (signal) {
       signal.addEventListener('abort', abort, { once: true });
-      registerRequestSignalCleanup(controller, () => signal.removeEventListener('abort', abort));
+      registerRequestSignalCleanup(controller, signal, abort);
     }
 
     const isReadableBody =

--- a/src/client.ts
+++ b/src/client.ts
@@ -9,6 +9,7 @@ export type { Logger, LogLevel } from './internal/utils/log';
 import { castToError, isAbortError } from './internal/errors';
 import type { APIResponseProps } from './internal/parse';
 import { getPlatformHeaders } from './internal/detect-platform';
+import { registerRequestSignalCleanup, releaseRequestSignal } from './internal/request-signal';
 import * as Shims from './internal/shims';
 import * as Opts from './internal/request-options';
 import { stringifyQuery } from './internal/utils/query';
@@ -1057,6 +1058,7 @@ export class BaseAnthropic {
     const headersTime = Date.now();
 
     if (response instanceof globalThis.Error) {
+      releaseRequestSignal(controller);
       const retryMessage = `retrying, ${retriesRemaining} attempts remaining`;
       if (options.signal?.aborted) {
         throw new Errors.APIUserAbortError();
@@ -1142,6 +1144,7 @@ export class BaseAnthropic {
 
         // We don't need the body of this response.
         await Shims.CancelReadableStream(response.body);
+        releaseRequestSignal(controller);
         loggerFor(this).info(`${responseInfo} - ${retryMessage}`);
         loggerFor(this).debug(
           `[${requestLogID}] response error (${retryMessage})`,
@@ -1181,6 +1184,7 @@ export class BaseAnthropic {
         }),
       );
 
+      releaseRequestSignal(controller);
       const err = this.makeStatusError(response.status, errJSON, errMessage, response.headers);
       throw err;
     }
@@ -1240,7 +1244,10 @@ export class BaseAnthropic {
     // the lifetime of the signal. Using `.bind()` only retains a reference to the
     // controller itself.
     const abort = this._makeAbort(controller);
-    if (signal) signal.addEventListener('abort', abort, { once: true });
+    if (signal) {
+      signal.addEventListener('abort', abort, { once: true });
+      registerRequestSignalCleanup(controller, () => signal.removeEventListener('abort', abort));
+    }
 
     const isReadableBody =
       ((globalThis as any).ReadableStream && options.body instanceof (globalThis as any).ReadableStream) ||

--- a/src/client.ts
+++ b/src/client.ts
@@ -9,7 +9,11 @@ export type { Logger, LogLevel } from './internal/utils/log';
 import { castToError, isAbortError } from './internal/errors';
 import type { APIResponseProps } from './internal/parse';
 import { getPlatformHeaders } from './internal/detect-platform';
-import { registerRequestSignalCleanup, releaseRequestSignal } from './internal/request-signal';
+import {
+  armAbandonmentBackstop,
+  registerRequestSignalCleanup,
+  releaseRequestSignal,
+} from './internal/request-signal';
 import * as Shims from './internal/shims';
 import * as Opts from './internal/request-options';
 import { stringifyQuery } from './internal/utils/query';
@@ -1201,6 +1205,7 @@ export class BaseAnthropic {
       }),
     );
 
+    armAbandonmentBackstop(response, controller);
     return { response, options, controller, requestLogID, retryOfRequestLogID, startTime };
   }
 

--- a/src/core/streaming.ts
+++ b/src/core/streaming.ts
@@ -11,6 +11,7 @@ import type { BaseAnthropic } from '../client';
 
 import { APIError } from './error';
 import type { ErrorType } from '../resources/shared';
+import { releaseRequestSignal } from '../internal/request-signal';
 
 type Bytes = string | ArrayBuffer | Uint8Array | null | undefined;
 
@@ -149,6 +150,7 @@ export class Stream<Item> implements AsyncIterable<Item> {
       } finally {
         // If the user `break`s, abort the ongoing request.
         if (!done) controller.abort();
+        releaseRequestSignal(controller);
       }
     }
 
@@ -200,6 +202,7 @@ export class Stream<Item> implements AsyncIterable<Item> {
       } finally {
         // If the user `break`s, abort the ongoing request.
         if (!done) controller.abort();
+        releaseRequestSignal(controller);
       }
     }
 

--- a/src/internal/parse.ts
+++ b/src/internal/parse.ts
@@ -4,6 +4,7 @@ import type { FinalRequestOptions } from './request-options';
 import { Stream } from '../core/streaming';
 import { type BaseAnthropic } from '../client';
 import { formatRequestDetails, loggerFor } from './utils/log';
+import { releaseRequestSignal } from './request-signal';
 import type { AbstractPage } from '../core/pagination';
 
 export type APIResponseProps = {
@@ -55,7 +56,15 @@ export async function defaultParseResponse<T>(
 
     const text = await response.text();
     return text as unknown as T;
-  })();
+  })().finally(() => {
+    // The body is settled (or parsing threw), so the caller-signal abort
+    // listener has nothing left to cancel. Streams release in their own
+    // teardown; a raw Response (`__binaryResponse`) keeps the listener so
+    // aborting an in-flight download still works.
+    if (!props.options.stream && !props.options.__binaryResponse) {
+      releaseRequestSignal(props.controller);
+    }
+  });
   loggerFor(client).debug(
     `[${requestLogID}] response parsed`,
     formatRequestDetails({

--- a/src/internal/request-signal.ts
+++ b/src/internal/request-signal.ts
@@ -34,12 +34,28 @@ const registry: AbandonmentRegistry | null =
     )
   : null;
 
-export function registerRequestSignalCleanup(controller: AbortController, cleanup: () => void): void {
-  cleanups.set(controller, cleanup);
+// Module-scope factory so the cleanup closure captures exactly the signal and
+// the listener - built at the `fetchWithTimeout` call site it would share that
+// scope's context and retain the request body for as long as the cleanup is
+// held (same reason `_makeAbort` exists in client.ts).
+function makeCleanup(signal: AbortSignal, listener: () => void): () => void {
+  return () => signal.removeEventListener('abort', listener);
 }
 
-export function armAbandonmentBackstop(response: object, controller: AbortController): void {
-  if (cleanups.has(controller)) registry?.register(response, controller, controller);
+export function registerRequestSignalCleanup(
+  controller: AbortController,
+  signal: AbortSignal,
+  listener: () => void,
+): void {
+  cleanups.set(controller, makeCleanup(signal, listener));
+}
+
+// The registered target is the response BODY, not the Response: a caller can
+// keep a reader on the body and drop the Response wrapper (`.asResponse()`),
+// and the listener must survive for as long as anything can still read - the
+// body is what a live read keeps alive.
+export function armAbandonmentBackstop(body: object, controller: AbortController): void {
+  if (cleanups.has(controller)) registry?.register(body, controller, controller);
 }
 
 export function releaseRequestSignal(controller: AbortController): void {

--- a/src/internal/request-signal.ts
+++ b/src/internal/request-signal.ts
@@ -14,14 +14,39 @@
  */
 const cleanups = new WeakMap<AbortController, () => void>();
 
+// Backstop for requests that never reach an explicit release point: a caller
+// that partially iterates a stream (or receives a raw binary Response) and
+// drops the reference never completes, errors, or cancels it, so the only
+// remaining lifecycle event is the response being collected. Finalization
+// timing is GC-driven and not guaranteed, so this only bounds abandonment -
+// the explicit release calls stay the primary cleanup. The held value must
+// not reference the response, or it could never be collected. Typed
+// structurally because the compiler lib is es2020.
+type AbandonmentRegistry = {
+  register(target: object, heldValue: AbortController, token: object): void;
+  unregister(token: object): void;
+};
+
+const registry: AbandonmentRegistry | null =
+  typeof (globalThis as any).FinalizationRegistry === 'function' ?
+    new (globalThis as any).FinalizationRegistry((controller: AbortController) =>
+      releaseRequestSignal(controller),
+    )
+  : null;
+
 export function registerRequestSignalCleanup(controller: AbortController, cleanup: () => void): void {
   cleanups.set(controller, cleanup);
+}
+
+export function armAbandonmentBackstop(response: object, controller: AbortController): void {
+  if (cleanups.has(controller)) registry?.register(response, controller, controller);
 }
 
 export function releaseRequestSignal(controller: AbortController): void {
   const cleanup = cleanups.get(controller);
   if (cleanup) {
     cleanups.delete(controller);
+    registry?.unregister(controller);
     cleanup();
   }
 }

--- a/src/internal/request-signal.ts
+++ b/src/internal/request-signal.ts
@@ -1,0 +1,27 @@
+/**
+ * Tracks the removal of the per-request abort listener that
+ * `fetchWithTimeout` attaches to a caller-provided signal, so the listener's
+ * lifetime matches the request instead of the signal.
+ *
+ * Without removal, a long-lived signal (e.g. one AbortController reused for
+ * a whole session) accumulates one `{ once: true }` listener plus its bound
+ * AbortController per HTTP attempt until the signal fires or is collected,
+ * and Node warns at the 11th listener. The listener must survive until the
+ * response body is settled - removing it when fetch resolves (headers) would
+ * break aborting an in-flight body read - so the code that finishes the body
+ * (response parsing, stream teardown, retry/error handling) calls
+ * `releaseRequestSignal` with the request's controller.
+ */
+const cleanups = new WeakMap<AbortController, () => void>();
+
+export function registerRequestSignalCleanup(controller: AbortController, cleanup: () => void): void {
+  cleanups.set(controller, cleanup);
+}
+
+export function releaseRequestSignal(controller: AbortController): void {
+  const cleanup = cleanups.get(controller);
+  if (cleanup) {
+    cleanups.delete(controller);
+    cleanup();
+  }
+}

--- a/tests/abort-listener-cleanup.test.ts
+++ b/tests/abort-listener-cleanup.test.ts
@@ -1,4 +1,6 @@
 import { getEventListeners } from 'node:events';
+import { runInNewContext } from 'node:vm';
+import { setFlagsFromString } from 'node:v8';
 import Anthropic from '@anthropic-ai/sdk';
 import { APIUserAbortError } from '@anthropic-ai/sdk';
 
@@ -167,6 +169,30 @@ describe('abort listener cleanup on a long-lived signal', () => {
     await new Promise((r) => setTimeout(r, 0));
     session.abort();
     await expect(pending).rejects.toThrow(APIUserAbortError);
+    expect(listenerCount(session.signal)).toBe(0);
+  });
+
+  test('an abandoned partially-iterated stream is released by the GC backstop', async () => {
+    const session = new AbortController();
+    const client = new Anthropic({ apiKey: 'sk-test', fetch: () => Promise.resolve(sseResponse()) });
+    await (async () => {
+      const stream = await client.messages.create(
+        { model: 'claude-test', max_tokens: 16, messages: [{ role: 'user', content: 'hi' }], stream: true },
+        { signal: session.signal },
+      );
+      const iterator = stream[Symbol.asyncIterator]();
+      await iterator.next();
+    })();
+    expect(listenerCount(session.signal)).toBe(1);
+
+    setFlagsFromString('--expose-gc');
+    const gc = runInNewContext('gc') as () => void;
+    setFlagsFromString('--no-expose-gc');
+    const deadline = Date.now() + 5000;
+    while (listenerCount(session.signal) > 0 && Date.now() < deadline) {
+      gc();
+      await new Promise((resolve) => setTimeout(resolve, 25));
+    }
     expect(listenerCount(session.signal)).toBe(0);
   });
 });

--- a/tests/abort-listener-cleanup.test.ts
+++ b/tests/abort-listener-cleanup.test.ts
@@ -1,0 +1,172 @@
+import { getEventListeners } from 'node:events';
+import Anthropic from '@anthropic-ai/sdk';
+import { APIUserAbortError } from '@anthropic-ai/sdk';
+
+const MESSAGE = {
+  id: 'msg_test',
+  type: 'message',
+  role: 'assistant',
+  content: [{ type: 'text', text: 'ok' }],
+  model: 'claude-test',
+  stop_reason: 'end_turn',
+  stop_sequence: null,
+  usage: { input_tokens: 1, output_tokens: 1 },
+};
+
+const jsonResponse = () =>
+  new Response(JSON.stringify(MESSAGE), { headers: { 'Content-Type': 'application/json' } });
+
+const sseResponse = () => {
+  const events: Array<[string, object]> = [
+    ['message_start', { type: 'message_start', message: { ...MESSAGE, content: [], stop_reason: null } }],
+    [
+      'content_block_start',
+      { type: 'content_block_start', index: 0, content_block: { type: 'text', text: '' } },
+    ],
+    [
+      'content_block_delta',
+      { type: 'content_block_delta', index: 0, delta: { type: 'text_delta', text: 'ok' } },
+    ],
+    ['content_block_stop', { type: 'content_block_stop', index: 0 }],
+    [
+      'message_delta',
+      {
+        type: 'message_delta',
+        delta: { stop_reason: 'end_turn', stop_sequence: null },
+        usage: { output_tokens: 1 },
+      },
+    ],
+    ['message_stop', { type: 'message_stop' }],
+  ];
+  const body = events.map(([event, data]) => `event: ${event}\ndata: ${JSON.stringify(data)}\n\n`).join('');
+  return new Response(body, { headers: { 'Content-Type': 'text/event-stream' } });
+};
+
+const listenerCount = (signal: AbortSignal) => getEventListeners(signal as any, 'abort').length;
+
+describe('abort listener cleanup on a long-lived signal', () => {
+  test('settled requests leave no listeners', async () => {
+    const client = new Anthropic({ apiKey: 'sk-test', fetch: () => Promise.resolve(jsonResponse()) });
+    const session = new AbortController();
+    for (let i = 0; i < 3; i++) {
+      await client.messages.create(
+        { model: 'claude-test', max_tokens: 16, messages: [{ role: 'user', content: 'hi' }] },
+        { signal: session.signal },
+      );
+    }
+    expect(listenerCount(session.signal)).toBe(0);
+  });
+
+  test('failed requests leave no listeners', async () => {
+    const client = new Anthropic({
+      apiKey: 'sk-test',
+      maxRetries: 0,
+      fetch: () =>
+        Promise.resolve(
+          new Response(JSON.stringify({ error: { type: 'invalid_request_error', message: 'bad' } }), {
+            status: 400,
+            headers: { 'Content-Type': 'application/json' },
+          }),
+        ),
+    });
+    const session = new AbortController();
+    await expect(
+      client.messages.create(
+        { model: 'claude-test', max_tokens: 16, messages: [{ role: 'user', content: 'hi' }] },
+        { signal: session.signal },
+      ),
+    ).rejects.toThrow();
+    expect(listenerCount(session.signal)).toBe(0);
+  });
+
+  test('connection errors leave no listeners', async () => {
+    const client = new Anthropic({
+      apiKey: 'sk-test',
+      maxRetries: 0,
+      fetch: () => Promise.reject(new Error('ECONNREFUSED')),
+    });
+    const session = new AbortController();
+    await expect(
+      client.messages.create(
+        { model: 'claude-test', max_tokens: 16, messages: [{ role: 'user', content: 'hi' }] },
+        { signal: session.signal },
+      ),
+    ).rejects.toThrow();
+    expect(listenerCount(session.signal)).toBe(0);
+  });
+
+  test('retried requests release each attempt', async () => {
+    let calls = 0;
+    const client = new Anthropic({
+      apiKey: 'sk-test',
+      maxRetries: 1,
+      fetch: () => {
+        calls++;
+        if (calls === 1) {
+          return Promise.resolve(
+            new Response(JSON.stringify({ error: { type: 'rate_limit_error', message: 'slow down' } }), {
+              status: 429,
+              headers: { 'Content-Type': 'application/json', 'retry-after': '0' },
+            }),
+          );
+        }
+        return Promise.resolve(jsonResponse());
+      },
+    });
+    const session = new AbortController();
+    await client.messages.create(
+      { model: 'claude-test', max_tokens: 16, messages: [{ role: 'user', content: 'hi' }] },
+      { signal: session.signal },
+    );
+    expect(calls).toBe(2);
+    expect(listenerCount(session.signal)).toBe(0);
+  });
+
+  test('consumed streams leave no listeners', async () => {
+    const client = new Anthropic({ apiKey: 'sk-test', fetch: () => Promise.resolve(sseResponse()) });
+    const session = new AbortController();
+    for (let i = 0; i < 2; i++) {
+      const stream = await client.messages.create(
+        { model: 'claude-test', max_tokens: 16, messages: [{ role: 'user', content: 'hi' }], stream: true },
+        { signal: session.signal },
+      );
+      for await (const _event of stream) {
+        // drain
+      }
+    }
+    expect(listenerCount(session.signal)).toBe(0);
+  });
+
+  test('a stream broken early releases its listener', async () => {
+    const client = new Anthropic({ apiKey: 'sk-test', fetch: () => Promise.resolve(sseResponse()) });
+    const session = new AbortController();
+    const stream = await client.messages.create(
+      { model: 'claude-test', max_tokens: 16, messages: [{ role: 'user', content: 'hi' }], stream: true },
+      { signal: session.signal },
+    );
+    for await (const _event of stream) {
+      break;
+    }
+    expect(listenerCount(session.signal)).toBe(0);
+  });
+
+  test('abort still cancels an in-flight request', async () => {
+    const client = new Anthropic({
+      apiKey: 'sk-test',
+      maxRetries: 0,
+      fetch: (_url, init) =>
+        new Promise((_resolve, reject) => {
+          init?.signal?.addEventListener('abort', () => reject(new DOMException('aborted', 'AbortError')));
+        }),
+    });
+    const session = new AbortController();
+    const pending = client.messages.create(
+      { model: 'claude-test', max_tokens: 16, messages: [{ role: 'user', content: 'hi' }] },
+      { signal: session.signal },
+    );
+    await new Promise((r) => setTimeout(r, 0));
+    session.abort();
+    await expect(pending).rejects.toThrow(APIUserAbortError);
+    expect(listenerCount(session.signal)).toBe(0);
+  });
+});

--- a/tests/abort-listener-cleanup.test.ts
+++ b/tests/abort-listener-cleanup.test.ts
@@ -172,6 +172,38 @@ describe('abort listener cleanup on a long-lived signal', () => {
     expect(listenerCount(session.signal)).toBe(0);
   });
 
+  test('holding only the body reader keeps the listener armed; dropping it releases', async () => {
+    const session = new AbortController();
+    const client = new Anthropic({ apiKey: 'sk-test', fetch: () => Promise.resolve(sseResponse()) });
+    let reader: ReadableStreamDefaultReader | null = await (async () => {
+      const response = await client.messages
+        .create(
+          { model: 'claude-test', max_tokens: 16, messages: [{ role: 'user', content: 'hi' }], stream: true },
+          { signal: session.signal },
+        )
+        .asResponse();
+      return response.body!.getReader();
+    })();
+    await reader.read();
+
+    setFlagsFromString('--expose-gc');
+    const gc = runInNewContext('gc') as () => void;
+    setFlagsFromString('--no-expose-gc');
+    for (let i = 0; i < 10; i++) {
+      gc();
+      await new Promise((resolve) => setTimeout(resolve, 10));
+    }
+    expect(listenerCount(session.signal)).toBe(1);
+
+    reader = null;
+    const deadline = Date.now() + 5000;
+    while (listenerCount(session.signal) > 0 && Date.now() < deadline) {
+      gc();
+      await new Promise((resolve) => setTimeout(resolve, 25));
+    }
+    expect(listenerCount(session.signal)).toBe(0);
+  });
+
   test('an abandoned partially-iterated stream is released by the GC backstop', async () => {
     const session = new AbortController();
     const client = new Anthropic({ apiKey: 'sk-test', fetch: () => Promise.resolve(sseResponse()) });


### PR DESCRIPTION
The client adds a `{ once: true }` abort listener to a caller-provided signal for every HTTP attempt (`fetchWithTimeout`) and never removes it. A long-lived signal - one AbortController reused across a session - accumulates one listener plus its bound per-attempt AbortController per request until the signal fires or is collected, and Node prints `MaxListenersExceededWarning` at the 11th. The bound `abort` already keeps each entry's retained graph small; the count is what grows without bound.

The listener can't be removed when fetch resolves - it has to survive until the body settles, or aborting an in-flight body read stops propagating. So the removal is registered in a WeakMap keyed by the per-request controller (`src/internal/request-signal.ts`) and released at the points that already own the end of a request: buffered-body parsing (`internal/parse.ts`), stream teardown (both SSE iterators' existing `finally` in `core/streaming.ts`), the retry path (right after the body cancel), and the connection-error and status-error paths in `makeRequest`. A raw `Response` handed back to the caller (`__binaryResponse`, `.asResponse()`) keeps its listener so aborting an in-flight download still works - the change is strictly a release, never an earlier cutoff.

`tests/abort-listener-cleanup.test.ts` pins it: settled, failed, connection-error, and retried requests plus consumed and early-broken streams all leave zero listeners on the caller signal (six of the seven fail before this change), and abort still cancels an in-flight request. For what it's worth the same pattern is in the other Stainless SDKs - happy to point this at the generator instead if that's the better home.

Update: added a FinalizationRegistry backstop for responses that never reach a release point - a partially iterated stream or a raw binary response whose reference is dropped. It holds only the request controller (never the response), and explicit release unregisters it, so deterministic cleanup stays primary. Feature-detected; every supported runtime has it (ES2021). New test: abandon a half-iterated stream, listener is released after collection - fails without the backstop.