### PR TITLE
fix(streaming): await async event listener callbacks before resolving done()

### DIFF
--- a/src/lib/BetaMessageStream.ts
+++ b/src/lib/BetaMessageStream.ts
@@ -70,6 +70,7 @@ export class BetaMessageStream<ParsedT = null> implements AsyncIterable<BetaMess
 
   #ended = false;
   #errored = false;
+  #listenerAwaitQueue: Promise<unknown>[] = [];
   #aborted = false;
   #catchingPromiseCreated = false;
   #response: Response | null | undefined;
@@ -389,13 +390,27 @@ export class BetaMessageStream<ParsedT = null> implements AsyncIterable<BetaMess
 
     if (event === 'end') {
       this.#ended = true;
-      this.#resolveEndPromise();
     }
 
     const listeners: MessageStreamEventListeners<Event> | undefined = this.#listeners[event];
     if (listeners) {
       this.#listeners[event] = listeners.filter((l) => !l.once) as any;
-      listeners.forEach(({ listener }: any) => listener(...args));
+      for (const { listener } of listeners as any[]) {
+        const result = (listener as any)(...args);
+        if (result instanceof Promise) {
+          this.#listenerAwaitQueue.push(result);
+        }
+      }
+    }
+
+    if (event === 'end') {
+      const queue = this.#listenerAwaitQueue.splice(0);
+      const settle = () => this.#resolveEndPromise();
+      if (queue.length) {
+        Promise.all(queue).then(settle, settle);
+      } else {
+        settle();
+      }
     }
 
     if (event === 'abort') {

--- a/src/lib/MessageStream.ts
+++ b/src/lib/MessageStream.ts
@@ -69,6 +69,7 @@ export class MessageStream<ParsedT = null> implements AsyncIterable<MessageStrea
 
   #ended = false;
   #errored = false;
+  #listenerAwaitQueue: Promise<unknown>[] = [];
   #aborted = false;
   #catchingPromiseCreated = false;
   #response: Response | null | undefined;
@@ -397,13 +398,27 @@ export class MessageStream<ParsedT = null> implements AsyncIterable<MessageStrea
 
     if (event === 'end') {
       this.#ended = true;
-      this.#resolveEndPromise();
     }
 
     const listeners: MessageStreamEventListeners<ParsedT, Event> | undefined = this.#listeners[event];
     if (listeners) {
       this.#listeners[event] = listeners.filter((l: { once?: boolean }) => !l.once) as any;
-      listeners.forEach(({ listener }: any) => listener(...args));
+      for (const { listener } of listeners as any[]) {
+        const result = (listener as any)(...args);
+        if (result instanceof Promise) {
+          this.#listenerAwaitQueue.push(result);
+        }
+      }
+    }
+
+    if (event === 'end') {
+      const queue = this.#listenerAwaitQueue.splice(0);
+      const settle = () => this.#resolveEndPromise();
+      if (queue.length) {
+        Promise.all(queue).then(settle, settle);
+      } else {
+        settle();
+      }
     }
 
     if (event === 'abort') {


### PR DESCRIPTION
Fixes #775.

`stream.on('message', async (msg) => { ... })` and similar async handlers are currently fire-and-forget. The internal `_emit` method calls `listeners.forEach(({ listener }) => listener(...args))` — synchronous, no `await` — so Promises returned by async handlers are never tracked. `done()` (and `await stream`) resolves immediately after the `'end'` event fires, before any async listeners complete.

The fix adds a `#listenerAwaitQueue` private field to both `MessageStream` and `BetaMessageStream`. When `_emit` runs listeners, any returned `Promise` is pushed into the queue. When the `'end'` event fires, resolution of the end promise is deferred until all queued Promises settle via `Promise.all`. Sync handlers are unaffected — they return `undefined`, which is not pushed to the queue. Errors from async listeners resolve the end promise rather than leaving it pending (the unhandled rejection from the listener propagates normally to the user).