### PR TITLE
fix: use a stable SDK user agent

### DIFF
--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -49,6 +49,19 @@ describe('instantiate client', () => {
       });
       expect(req.headers.has('x-my-default-header')).toBe(false);
     });
+
+    test('uses a stable user agent for subclasses', async () => {
+      class MinifiedClient extends Anthropic {}
+
+      const subclassedClient = new MinifiedClient({
+        baseURL: 'http://localhost:5000/',
+        apiKey: 'my-anthropic-api-key',
+      });
+      const { req } = await subclassedClient.buildRequest({ path: '/foo', method: 'post' });
+
+      expect(req.headers.get('user-agent')).toMatch(/^Anthropic\/JS /);
+      expect(req.headers.get('user-agent')).not.toContain('MinifiedClient');
+    });
   });
   describe('logging', () => {
     const env = process.env;


### PR DESCRIPTION
## Summary
- make the API request User-Agent independent of the runtime constructor name
- preserve the existing `Anthropic/JS <version>` format
- add regression coverage using a subclass whose constructor name differs

## Why
`constructor.name` can be changed by minification or subclassing, producing an unpredictable SDK identity in network traffic. A constant SDK token keeps observability and client identification stable across builds.

## Validation
- `yarn jest tests/index.test.ts --runInBand` (51 tests passed)
- Prettier check on changed files
- ESLint on changed files
- TypeScript `tsc --noEmit`

Closes #1134
