### PR TITLE
fix: replace constructor.name with literal string in getUserAgent

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -863,7 +863,7 @@ export class BaseAnthropic {
   }
 
   private getUserAgent(): string {
-    return `${this.constructor.name}/JS ${VERSION}`;
+    return `Anthropic/JS ${VERSION}`;
   }
 
   protected defaultIdempotencyKey(): string {


### PR DESCRIPTION
When the SDK is bundled with a minifier, `this.constructor.name` gets mangled to a single-character identifier (`r`, `e`, etc.), producing user-agent strings like `Anthropic-JS/r 0.x.x` instead of `Anthropic-JS/Anthropic 0.x.x`.

Replace the runtime-computed name with the literal string `'Anthropic'`, which is always stable after minification.

Related: anthropics/anthropic-sdk-typescript#1134