### PR TITLE
fix(schema): preserve const/enum in transformJSONSchema

### DIFF
--- a/src/lib/transform-json-schema.ts
+++ b/src/lib/transform-json-schema.ts
@@ -71,6 +71,19 @@ function _transformJSONSchema(jsonSchema: JSONSchema): JSONSchema {
     strictSchema['title'] = title;
   }
 
+  // Preserve machine-readable discriminants. Dumping these into `description`
+  // breaks Zod discriminated unions / literal branches in tool input schemas
+  // (https://github.com/anthropics/anthropic-sdk-typescript/issues/1116).
+  const constValue = pop(jsonSchema, 'const');
+  if (constValue !== undefined) {
+    strictSchema['const'] = constValue;
+  }
+
+  const enumValue = pop(jsonSchema, 'enum');
+  if (enumValue !== undefined) {
+    strictSchema['enum'] = enumValue;
+  }
+
   if (type === 'object') {
     const properties = pop(jsonSchema, 'properties') || {};
 

--- a/src/lib/transform-json-schema.ts
+++ b/src/lib/transform-json-schema.ts
@@ -72,8 +72,10 @@ function _transformJSONSchema(jsonSchema: JSONSchema): JSONSchema {
   }
 
   // Preserve machine-readable discriminants. Dumping these into `description`
-  // breaks Zod discriminated unions / literal branches in tool input schemas
-  // (https://github.com/anthropics/anthropic-sdk-typescript/issues/1116).
+  // breaks Zod discriminated unions / literal branches for helpers that run
+  // through this transformer (e.g. betaZodOutputFormat / jsonSchemaOutputFormat).
+  // See https://github.com/anthropics/anthropic-sdk-typescript/issues/1116
+  // (note: betaZodTool does not call transformJSONSchema today).
   const constValue = pop(jsonSchema, 'const');
   if (constValue !== undefined) {
     strictSchema['const'] = constValue;

--- a/tests/helpers/beta/zod.test.ts
+++ b/tests/helpers/beta/zod.test.ts
@@ -1,5 +1,5 @@
 import * as z from 'zod/v4';
-import { betaZodTool } from '../../../src/helpers/beta/zod';
+import { betaZodOutputFormat, betaZodTool } from '../../../src/helpers/beta/zod';
 
 describe('zod helpers', () => {
   describe('zodTool', () => {
@@ -97,6 +97,32 @@ describe('zod helpers', () => {
 
       const result = await tool.run({ delay: 1, message: 'done' });
       expect(result).toBe('done');
+    });
+  });
+
+  describe('betaZodOutputFormat', () => {
+    it('preserves const discriminants after transformJSONSchema', () => {
+      const format = betaZodOutputFormat(
+        z.discriminatedUnion('kind', [
+          z.object({ kind: z.literal('set_title'), title: z.string() }),
+          z.object({ kind: z.literal('add_members'), emails: z.array(z.string()) }),
+        ]),
+      );
+
+      const schema = format.schema as {
+        anyOf?: Array<{ properties?: { kind?: Record<string, unknown> } }>;
+      };
+      const kinds = (schema.anyOf ?? []).map((variant) => variant.properties?.kind);
+
+      expect(kinds).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({ type: 'string', const: 'set_title' }),
+          expect.objectContaining({ type: 'string', const: 'add_members' }),
+        ]),
+      );
+      for (const kind of kinds) {
+        expect(kind?.description).toBeUndefined();
+      }
     });
   });
 });

--- a/tests/helpers/transform-json-schema.test.ts
+++ b/tests/helpers/transform-json-schema.test.ts
@@ -481,7 +481,9 @@ describe('transformJsonSchema', () => {
 `);
   });
 
-  it('preserves const and enum for discriminated-union branches (#1116)', () => {
+  it('preserves const and enum for discriminated-union branches (output-format path)', () => {
+    // betaZodOutputFormat / jsonSchemaOutputFormat run schemas through
+    // transformJSONSchema; betaZodTool does not today (#1116 discussion).
     const input = {
       type: 'object',
       properties: {

--- a/tests/helpers/transform-json-schema.test.ts
+++ b/tests/helpers/transform-json-schema.test.ts
@@ -480,4 +480,46 @@ describe('transformJsonSchema', () => {
 }
 `);
   });
+
+  it('preserves const and enum for discriminated-union branches (#1116)', () => {
+    const input = {
+      type: 'object',
+      properties: {
+        change: {
+          anyOf: [
+            {
+              type: 'object',
+              properties: {
+                action: { type: 'string', const: 'set_title' },
+                title: { type: 'string' },
+              },
+              required: ['action', 'title'],
+            },
+            {
+              type: 'object',
+              properties: {
+                action: { type: 'string', enum: ['add_members'] },
+                emails: { type: 'array', items: { type: 'string' } },
+              },
+              required: ['action', 'emails'],
+            },
+          ],
+        },
+      },
+      required: ['change'],
+    };
+
+    const result = transformJSONSchema(input);
+
+    expect(result.properties.change.anyOf[0].properties.action).toEqual({
+      type: 'string',
+      const: 'set_title',
+    });
+    expect(result.properties.change.anyOf[1].properties.action).toEqual({
+      type: 'string',
+      enum: ['add_members'],
+    });
+    expect(result.properties.change.anyOf[0].properties.action.description).toBeUndefined();
+    expect(result.properties.change.anyOf[1].properties.action.description).toBeUndefined();
+  });
 });


### PR DESCRIPTION
## Summary
- Keeps `const` and `enum` on the strict schema in `transformJSONSchema` instead of dumping them into `description`.
- This matters for helpers that run schemas through the transformer (`betaZodOutputFormat`, `jsonSchemaOutputFormat`, and the non-beta equivalents). Discriminants stay machine-readable.
- Note: `betaZodTool` does **not** call `transformJSONSchema` today — #1116’s tools-path writeup needs a separate re-check. Related discussion on #1116; this PR does not claim to close that issue’s tools symptom.

Related to #1116

## Test plan
- [x] `yarn jest tests/helpers/transform-json-schema.test.ts tests/helpers/beta/zod.test.ts`
- [x] `betaZodOutputFormat(z.discriminatedUnion(...))` keeps `const` on each branch