### PR TITLE
fix(client): wire idempotencyKey to Idempotency-Key header

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -569,6 +569,9 @@ export class BaseAnthropic {
     this.maxRetries = options.maxRetries ?? 2;
     this.fetch = options.fetch ?? Shims.getDefaultFetch();
     this.#encoder = Opts.FallbackEncoder;
+    // Wire RequestOptions.idempotencyKey → Idempotency-Key (otherwise the
+    // option is a silent no-op because this field stays undefined).
+    this.idempotencyHeader = 'Idempotency-Key';
 
     this.middleware = [...(options.middleware ?? [])];
 

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -50,6 +50,39 @@ describe('instantiate client', () => {
       expect(req.headers.has('x-my-default-header')).toBe(false);
     });
   });
+
+  describe('idempotencyKey', () => {
+    const client = new Anthropic({
+      baseURL: 'http://localhost:5000/',
+      apiKey: 'my-anthropic-api-key',
+    });
+
+    test('sends Idempotency-Key when idempotencyKey is provided', async () => {
+      const { req } = await client.buildRequest({
+        path: '/v1/messages',
+        method: 'post',
+        idempotencyKey: 'my-idempotency-key',
+      });
+      expect(req.headers.get('idempotency-key')).toEqual('my-idempotency-key');
+    });
+
+    test('auto-generates Idempotency-Key for non-GET when none is provided', async () => {
+      const { req } = await client.buildRequest({
+        path: '/v1/messages',
+        method: 'post',
+      });
+      expect(req.headers.get('idempotency-key')).toMatch(/^stainless-/);
+    });
+
+    test('does not send Idempotency-Key on GET', async () => {
+      const { req } = await client.buildRequest({
+        path: '/v1/models',
+        method: 'get',
+        idempotencyKey: 'should-not-appear',
+      });
+      expect(req.headers.get('idempotency-key')).toBeNull();
+    });
+  });
   describe('logging', () => {
     const env = process.env;
 


### PR DESCRIPTION
## Summary
- `RequestOptions.idempotencyKey` was accepted by types but silently dropped because the base client never set `idempotencyHeader`.
- Set `this.idempotencyHeader = 'Idempotency-Key'` so non-GET requests send the standard header (matches Anthropic CLI / Stainless convention).

## Test plan
- [x] `buildRequest` assertions for provided key, auto-generated key, and GET exclusion
- [x] Proven to fail without the fix (header was `null`)

Fixes #1112

Made with [Cursor](https://cursor.com)