### PR TITLE
docs(helpers): add missing .beta segment in toolRunner heading

### DIFF
--- a/helpers.md
+++ b/helpers.md
@@ -356,7 +356,7 @@ const calculatorTool = betaTool({
 });
 ```
 
-### `client.messages.toolRunner(params): BetaToolRunner`
+### `client.beta.messages.toolRunner(params): BetaToolRunner`
 
 **Parameters:** All standard message parameters plus:
 


### PR DESCRIPTION
The `toolRunner` method is only defined on the beta Messages resource (`src/resources/beta/messages/messages.ts`), not on the non-beta Messages resource. Every runnable example in `helpers.md` already calls `anthropic.beta.messages.toolRunner(...)`, so the heading at line 359 was missing the `.beta` segment.

This change updates the heading to match the actual API path.

I used Claude Code to assist with this one-line docs fix and reviewed the diff manually.
