### PR TITLE
fix(vertex): strip beta headers from countTokens requests

### DIFF
--- a/packages/vertex-sdk/src/client.ts
+++ b/packages/vertex-sdk/src/client.ts
@@ -210,6 +210,7 @@ export class AnthropicVertex extends BaseAnthropic {
       }
     }
 
+    let isCountTokens = false;
     if (
       options &&
       (options.path === '/v1/messages/count_tokens' ||
@@ -226,6 +227,7 @@ export class AnthropicVertex extends BaseAnthropic {
         const prefix = url.pathname.slice(0, url.pathname.length - canonicalPath.length);
         url.pathname = `${prefix}/projects/${this.projectId}/locations/${this.region}/publishers/anthropic/models/count-tokens:rawPredict`;
         url.searchParams.delete('beta');
+        isCountTokens = true;
       }
     }
 
@@ -234,7 +236,11 @@ export class AnthropicVertex extends BaseAnthropic {
       url: url.toString(),
       // Request/middleware-set headers win over the OAuth headers, preserving
       // the ability to override `Authorization` explicitly.
-      headers: buildHeaders([googleAuthHeaders, request.headers]).values,
+      headers: buildHeaders([
+        googleAuthHeaders,
+        request.headers,
+        isCountTokens ? { 'anthropic-beta': null } : undefined,
+      ]).values,
     } as APIRequest;
     if (parsedBody) {
       adapted.body = JSON.stringify(parsedBody);

--- a/packages/vertex-sdk/tests/client.test.ts
+++ b/packages/vertex-sdk/tests/client.test.ts
@@ -207,6 +207,56 @@ describe('AnthropicVertex', () => {
         'https://us-east5-aiplatform.googleapis.com/v1/projects/test-project/locations/us-east5/publishers/anthropic/models/count-tokens:rawPredict',
       );
     });
+
+    test('does not forward anthropic-beta on count_tokens requests', async () => {
+      const client = new AnthropicVertex({
+        region: 'us-east5',
+        projectId: 'test-project',
+        fetch: mockFetch as any,
+        defaultHeaders: { 'anthropic-beta': 'effort-2025-11-24' },
+      });
+
+      await client.messages.countTokens({
+        model: createParams.model,
+        messages: createParams.messages,
+      });
+
+      const [, wireInit] = mockFetch.mock.calls[0];
+      expect(new Headers(wireInit.headers).has('anthropic-beta')).toBe(false);
+    });
+
+    test('does not forward anthropic-beta on beta count_tokens requests', async () => {
+      const client = new AnthropicVertex({
+        region: 'us-east5',
+        projectId: 'test-project',
+        fetch: mockFetch as any,
+      });
+
+      await client.beta.messages.countTokens(
+        {
+          model: createParams.model,
+          messages: createParams.messages,
+        },
+        { headers: { 'anthropic-beta': 'effort-2025-11-24' } },
+      );
+
+      const [, wireInit] = mockFetch.mock.calls[0];
+      expect(new Headers(wireInit.headers).has('anthropic-beta')).toBe(false);
+    });
+
+    test('forwards anthropic-beta on regular messages requests', async () => {
+      const client = new AnthropicVertex({
+        region: 'us-east5',
+        projectId: 'test-project',
+        fetch: mockFetch as any,
+        defaultHeaders: { 'anthropic-beta': 'effort-2025-11-24' },
+      });
+
+      await client.messages.create(createParams);
+
+      const [, wireInit] = mockFetch.mock.calls[0];
+      expect(new Headers(wireInit.headers).get('anthropic-beta')).toBe('effort-2025-11-24');
+    });
   });
 
   test('user agent is a hardcoded string', async () => {


### PR DESCRIPTION
Fixes #1016

Vertex model backends do not roll out `anthropic-beta` values at the same time. A beta sent with `countTokens` can make a lagging model return HTTP 400, even though token counting does not need beta-gated capabilities.

This strips `anthropic-beta` only while Vertex adapts count-token requests. Regular message requests keep the header. The tests cover regular and beta count-token requests, plus a regular message request.

Tests:
- `yarn test --runInBand` from `packages/vertex-sdk`
- `yarn build` from `packages/vertex-sdk`
- targeted Prettier, ESLint, and TypeScript checks