### PR TITLE
docs: fix toolRunner heading to include .beta segment

### DIFF
--- a/helpers.md
+++ b/helpers.md
@@ -356,7 +356,7 @@ const calculatorTool = betaTool({
 });
 ```
 
-### `client.messages.toolRunner(params): BetaToolRunner`
+### `client.beta.messages.toolRunner(params): BetaToolRunner`
 
 **Parameters:** All standard message parameters plus:
 


### PR DESCRIPTION
`toolRunner` is only defined on the beta Messages resource (`src/resources/beta/messages/messages.ts`). The non-beta `src/resources/messages/messages.ts` exposes `create`/`parse`/`stream`/`countTokens`, but no `toolRunner`. Every runnable example already below this heading calls `anthropic.beta.messages.toolRunner(...)` — only the heading itself was missing the `.beta` segment, so the path as written doesn't resolve on the client.

One-line fix.

Fixes #1141