### PR TITLE
fix: preserve zero retry-after-ms precedence

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -1388,7 +1388,7 @@ export class BaseAnthropic {
 
     // About the Retry-After header: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Retry-After
     const retryAfterHeader = responseHeaders?.get('retry-after');
-    if (retryAfterHeader && !timeoutMillis) {
+    if (retryAfterHeader && timeoutMillis === undefined) {
       const timeoutSeconds = parseFloat(retryAfterHeader);
       if (!Number.isNaN(timeoutSeconds)) {
         timeoutMillis = timeoutSeconds * 1000;

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -774,6 +774,36 @@ describe('retries', () => {
     expect(count).toEqual(3);
   });
 
+  test('retry-after-ms zero takes precedence over retry-after', async () => {
+    let count = 0;
+    const setTimeoutSpy = jest.spyOn(globalThis, 'setTimeout');
+    const testFetch = async (
+      url: string | URL | Request,
+      { signal }: RequestInit = {},
+    ): Promise<Response> => {
+      if (count++ === 0) {
+        return new Response(undefined, {
+          status: 429,
+          headers: {
+            'Retry-After-Ms': '0',
+            'Retry-After': '0.05',
+          },
+        });
+      }
+      return new Response(JSON.stringify({ a: 1 }), { headers: { 'Content-Type': 'application/json' } });
+    };
+
+    const client = new Anthropic({ apiKey: 'my-anthropic-api-key', fetch: testFetch });
+
+    try {
+      expect(await client.request({ path: '/foo', method: 'get' })).toEqual({ a: 1 });
+      expect(count).toEqual(2);
+      expect(setTimeoutSpy).toHaveBeenCalledWith(expect.any(Function), 0);
+    } finally {
+      setTimeoutSpy.mockRestore();
+    }
+  });
+
   test('HTTP error response exposes error type', async () => {
     const client = new Anthropic({
       apiKey: 'test-key',


### PR DESCRIPTION
Summary:
- Preserve `retry-after-ms` precedence when the parsed delay is 0.
- Add regression coverage for responses that send both retry headers.

Reason:
`retry-after-ms` is parsed before `Retry-After`, but the follow-up guard treated a valid 0 ms delay as absent. When both headers were present, `Retry-After` could replace the more precise millisecond delay.

Verification:
- `pnpm exec jest tests/index.test.ts -t "retry-after-ms zero takes precedence over retry-after" --runInBand`
- `pnpm exec jest tests/index.test.ts -t "retries" --runInBand`
- `pnpm lint`