### PR TITLE
fix: handle Response uploads without URLs

### DIFF
--- a/src/internal/to-file.ts
+++ b/src/internal/to-file.ts
@@ -107,7 +107,9 @@ export async function toFile(
 
   if (isResponseLike(value)) {
     const blob = await value.blob();
-    name ||= new URL(value.url).pathname.split(/[\\/]/).pop();
+    if (!name && value.url) {
+      name = new URL(value.url).pathname.split(/[\\/]/).pop();
+    }
 
     return makeFile(await getBytes(blob), name, options);
   }

--- a/tests/uploads.test.ts
+++ b/tests/uploads.test.ts
@@ -43,6 +43,12 @@ describe('toFile', () => {
     expect(file.name).toEqual('audio.mp3');
   });
 
+  it('uses the default file name for a Response without a URL', async () => {
+    const file = await toFile(new Response('content'));
+    expect(file.name).toEqual('unknown_file');
+    await expect(file.text()).resolves.toEqual('content');
+  });
+
   it('extracts a file name from a File', async () => {
     const input = new File(['foo'], 'input.jsonl');
     const file = await toFile(input);


### PR DESCRIPTION
Summary:
- Let `toFile()` handle `Response` objects whose `url` is empty.
- Add regression coverage for the default filename fallback.

Reason:
The Fetch standard permits manually constructed `Response` objects to have an empty `url`. `toFile(new Response(...))` currently calls `new URL(value.url)` in the Response path and throws before it can fall back to `unknown_file`.

Verification:
- `pnpm exec jest tests/uploads.test.ts -t "Response without a URL" --runInBand`
- `pnpm exec jest tests/uploads.test.ts --runInBand`
- `pnpm lint`