### PR TITLE
fix: use client logger for stream parse errors

### DIFF
--- a/src/internal/parse.ts
+++ b/src/internal/parse.ts
@@ -28,7 +28,7 @@ export async function defaultParseResponse<T>(
       // Note: there is an invariant here that isn't represented in the type system
       // that if you set `stream: true` the response type must also be `Stream<T>`
 
-      return Stream.fromSSEResponse(response, props.controller) as any;
+      return Stream.fromSSEResponse(response, props.controller, client) as any;
     }
 
     // fetch refuses to read the body when the status code is 204.

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -176,6 +176,45 @@ describe('instantiate client', () => {
       expect(debugMock).not.toHaveBeenCalled();
     });
 
+    test('stream parse errors use the client logger', async () => {
+      const logger = {
+        debug: jest.fn(),
+        info: jest.fn(),
+        warn: jest.fn(),
+        error: jest.fn(),
+      };
+      const consoleError = jest.spyOn(console, 'error').mockImplementation(() => {});
+      const client = new Anthropic({
+        logger,
+        logLevel: 'error',
+        apiKey: 'my-anthropic-api-key',
+        fetch: async () =>
+          new Response('event: completion\ndata: not-json\n\n', {
+            headers: { 'content-type': 'text/event-stream' },
+          }),
+      });
+
+      try {
+        const stream = await client.messages.create({
+          messages: [],
+          model: 'claude-opus-4-8',
+          max_tokens: 1,
+          stream: true,
+        });
+
+        await expect(
+          (async () => {
+            for await (const _event of stream) {
+            }
+          })(),
+        ).rejects.toBeInstanceOf(SyntaxError);
+        expect(logger.error).toHaveBeenCalledTimes(2);
+        expect(consoleError).not.toHaveBeenCalled();
+      } finally {
+        consoleError.mockRestore();
+      }
+    });
+
     test('no warning logged for invalid env var level + valid client level', async () => {
       const warnMock = jest.fn();
       const logger = {


### PR DESCRIPTION
## Summary
- pass the active client to the SSE stream parser
- add regression coverage that malformed SSE diagnostics use the configured logger instead of the global console

## Testing
- corepack pnpm exec jest tests/index.test.ts --runInBand
- corepack pnpm lint

Fixes #1159