### PR TITLE
docs: fix missing .beta segment in toolRunner heading (#1141)

### DIFF
--- a/helpers.md
+++ b/helpers.md
@@ -356,7 +356,7 @@ const calculatorTool = betaTool({
 });
 ```
 
-### `client.messages.toolRunner(params): BetaToolRunner`
+### `client.beta.messages.toolRunner(params): BetaToolRunner`
 
 **Parameters:** All standard message parameters plus:
 


### PR DESCRIPTION
Fixes #1141

### Summary of Changes
- Corrected the method heading in `helpers.md` from `### \`client.messages.toolRunner(params): BetaToolRunner\`` to `### \`client.beta.messages.toolRunner(params): BetaToolRunner\``.
- Aligns the section heading with the actual SDK export on the `BetaMessages` resource (`src/resources/beta/messages/messages.ts`) and all code examples in `helpers.md`.