### PR TITLE
fix(schema): keep $defs when the schema root is a $ref

### DIFF
--- a/src/lib/transform-json-schema.ts
+++ b/src/lib/transform-json-schema.ts
@@ -28,12 +28,6 @@ export function transformJSONSchema(jsonSchema: JSONSchema): JSONSchema {
 function _transformJSONSchema(jsonSchema: JSONSchema): JSONSchema {
   const strictSchema: JSONSchema = {};
 
-  const ref = pop(jsonSchema, '$ref');
-  if (ref !== undefined) {
-    strictSchema['$ref'] = ref;
-    return strictSchema;
-  }
-
   const defs = pop(jsonSchema, '$defs');
   if (defs !== undefined) {
     const strictDefs: Record<string, any> = {};
@@ -41,6 +35,14 @@ function _transformJSONSchema(jsonSchema: JSONSchema): JSONSchema {
     for (const [name, defSchema] of Object.entries(defs)) {
       strictDefs[name] = _transformJSONSchema(defSchema as JSONSchema);
     }
+  }
+
+  // $defs must be processed before the $ref early-return below, so that a
+  // root-level `{"$ref": "#/$defs/X", "$defs": {...}}` keeps its definitions.
+  const ref = pop(jsonSchema, '$ref');
+  if (ref !== undefined) {
+    strictSchema['$ref'] = ref;
+    return strictSchema;
   }
 
   const type = pop(jsonSchema, 'type');

--- a/tests/helpers/transform-json-schema.test.ts
+++ b/tests/helpers/transform-json-schema.test.ts
@@ -204,6 +204,36 @@ describe('transformJsonSchema', () => {
 `);
   });
 
+  it('should keep $defs when the schema root is a $ref', () => {
+    // What pydantic's RootModel and zod-to-json-schema emit for a top-level
+    // model: the root is a $ref and the definitions sit beside it. Returning
+    // early on $ref used to drop $defs, leaving the reference dangling.
+    const input = {
+      $ref: '#/$defs/Person',
+      $defs: {
+        Person: {
+          type: 'object',
+          properties: {
+            name: { type: 'string' },
+          },
+        },
+      },
+    };
+
+    const result = transformJSONSchema(input);
+
+    expect(result).toEqual({
+      $defs: {
+        Person: {
+          type: 'object',
+          properties: { name: { type: 'string' } },
+          additionalProperties: false,
+        },
+      },
+      $ref: '#/$defs/Person',
+    });
+  });
+
   it('should handle $defs and definitions recursively', () => {
     const input = {
       type: 'object',


### PR DESCRIPTION
Fixes #1162.

### The bug

`transformJSONSchema` pops `$ref` and returns before it ever reads `$defs`, so a root-level `{"$ref": "#/$defs/X", "$defs": {...}}` comes back as `{"$ref": "#/$defs/X"}` — definitions gone, reference dangling.

That is what pydantic's `RootModel` and `zod-to-json-schema` emit for a top-level model, so it is a shape that arrives in normal use rather than an edge case. A `$ref` nested inside `properties` is unaffected; only the root case is.

Verified against the published package, not just `main`:

```console
$ npm i @anthropic-ai/sdk@0.120.0
$ node -e 'import("@anthropic-ai/sdk/lib/transform-json-schema").then(m=>console.log(JSON.stringify(
    m.transformJSONSchema({$ref:"#/$defs/Item",$defs:{Item:{type:"object",properties:{a:{type:"string"}}}}}))))'
{"$ref":"#/$defs/Item"}
```

### The change

Move the `$defs` block above the `$ref` early-return. Six lines reordered, plus the comment explaining why the order matters.

This is the same fix the Python SDK took for the same defect in [anthropics/anthropic-sdk-python#1642](https://github.com/anthropics/anthropic-sdk-python/pull/1642) (merged 2026-06-04). With it, the two SDKs agree on this input again:

```js
transformJSONSchema({ $ref: '#/$defs/Item', $defs: { Item: { type: 'object', properties: { a: { type: 'string' } } } } })
// { "$defs": { "Item": { "type": "object", "properties": { "a": { "type": "string" } }, "additionalProperties": false } },
//   "$ref": "#/$defs/Item" }
```

which matches what `anthropic` 1.0.0 returns for the equivalent Python call.

### Tests

One added, `should keep $defs when the schema root is a $ref`. It fails on `main` and passes with this change — I checked both ways rather than assuming:

```console
$ npx jest tests/helpers/transform-json-schema.test.ts     # with the fix
Tests:       13 passed, 13 total

$ npx jest tests/helpers/transform-json-schema.test.ts     # fix reverted, test kept
✕ should keep $defs when the schema root is a $ref
Tests:       1 failed, 12 passed, 13 total
```

The other 12 tests are untouched and still pass, including the existing `should handle $defs and definitions recursively` case, which exercises the nested-`$ref` path this does not change.

The rest of the repo's suite needs the prism mock server on `127.0.0.1:4010`, which I did not run; those failures are identical with and without this change.
