### PR TITLE
fix(BetaMessageStream): preserve null content and existing checkpoint in compaction_delta

### DIFF
--- a/src/lib/BetaMessageStream.ts
+++ b/src/lib/BetaMessageStream.ts
@@ -693,9 +693,9 @@ export class BetaMessageStream<ParsedT = null> implements AsyncIterable<BetaMess
               snapshot.content[event.index] = {
                 ...snapshotContent,
                 content:
-                  event.delta.content === null
-                    ? snapshotContent.content
-                    : (snapshotContent.content ?? '') + event.delta.content,
+                  event.delta.content === null ?
+                    snapshotContent.content
+                  : (snapshotContent.content ?? '') + event.delta.content,
                 encrypted_content: event.delta.encrypted_content ?? snapshotContent.encrypted_content,
               };
             }

--- a/src/lib/BetaMessageStream.ts
+++ b/src/lib/BetaMessageStream.ts
@@ -494,7 +494,7 @@ export class BetaMessageStream<ParsedT = null> implements AsyncIterable<BetaMess
             break;
           }
           case 'compaction_delta': {
-            if (content.type === 'compaction' && content.content) {
+            if (content.type === 'compaction' && content.content && event.delta.content !== null) {
               this._emit('compaction', content.content);
             }
             break;

--- a/src/lib/BetaMessageStream.ts
+++ b/src/lib/BetaMessageStream.ts
@@ -692,8 +692,11 @@ export class BetaMessageStream<ParsedT = null> implements AsyncIterable<BetaMess
             if (snapshotContent?.type === 'compaction') {
               snapshot.content[event.index] = {
                 ...snapshotContent,
-                content: (snapshotContent.content || '') + event.delta.content,
-                encrypted_content: event.delta.encrypted_content,
+                content:
+                  event.delta.content === null
+                    ? snapshotContent.content
+                    : (snapshotContent.content ?? '') + event.delta.content,
+                encrypted_content: event.delta.encrypted_content ?? snapshotContent.encrypted_content,
               };
             }
             break;

--- a/tests/api-resources/BetaMessageStream.test.ts
+++ b/tests/api-resources/BetaMessageStream.test.ts
@@ -778,153 +778,200 @@ describe('BetaMessageStream class', () => {
     ]);
   });
 
-  it("accumulates compaction_delta events without coercing null or dropping checkpoint", async () => {
+  it('accumulates compaction_delta events without coercing null or dropping checkpoint', async () => {
     const { fetch, handleStreamEvents } = mockFetch();
 
-    const anthropic = new Anthropic({ apiKey: "test-key", fetch });
+    const anthropic = new Anthropic({ apiKey: 'test-key', fetch });
 
     handleStreamEvents([
       {
-        type: "message_start",
+        type: 'message_start',
         message: {
-          id: "msg_compact_01",
-          type: "message",
-          role: "assistant",
+          id: 'msg_compact_01',
+          type: 'message',
+          role: 'assistant',
           content: [],
-          model: "claude-sonnet-4-5",
+          model: 'claude-sonnet-4-5',
           stop_reason: null,
           stop_sequence: null,
           usage: { input_tokens: 10, output_tokens: 1 },
         },
       },
       {
-        type: "content_block_start",
+        type: 'content_block_start',
         index: 0,
-        content_block: { type: "compaction", content: "", encrypted_content: "" },
+        content_block: { type: 'compaction', content: '', encrypted_content: '' },
       },
       {
-        type: "content_block_delta",
+        type: 'content_block_delta',
         index: 0,
         delta: {
-          type: "compaction_delta",
-          content: "Summary part 1",
-          encrypted_content: "ck_point_1",
+          type: 'compaction_delta',
+          content: 'Summary part 1',
+          encrypted_content: 'ck_point_1',
         },
       },
       {
-        type: "content_block_delta",
+        type: 'content_block_delta',
         index: 0,
         delta: {
-          type: "compaction_delta",
-          content: " part 2",
+          type: 'compaction_delta',
+          content: ' part 2',
           encrypted_content: null,
         },
       },
       {
-        type: "content_block_delta",
+        type: 'content_block_delta',
         index: 0,
         delta: {
-          type: "compaction_delta",
+          type: 'compaction_delta',
           content: null,
-          encrypted_content: "ck_point_2",
+          encrypted_content: 'ck_point_2',
         },
       },
       {
-        type: "content_block_delta",
+        type: 'content_block_delta',
         index: 0,
         delta: {
-          type: "compaction_delta",
-          content: " part 3",
+          type: 'compaction_delta',
+          content: ' part 3',
           encrypted_content: null,
         },
       },
-      { type: "content_block_stop", index: 0 },
+      { type: 'content_block_stop', index: 0 },
       {
-        type: "message_delta",
-        delta: { stop_reason: "end_turn", stop_sequence: null },
+        type: 'message_delta',
+        delta: { stop_reason: 'end_turn', stop_sequence: null },
         usage: { output_tokens: 10 },
       },
-      { type: "message_stop" },
+      { type: 'message_stop' },
     ]);
 
     const stream = anthropic.beta.messages.stream({
       max_tokens: 1024,
-      model: "claude-sonnet-4-5",
-      messages: [{ role: "user", content: "test" }],
+      model: 'claude-sonnet-4-5',
+      messages: [{ role: 'user', content: 'test' }],
     });
 
     const finalMessage = await stream.finalMessage();
     const compactionBlock = finalMessage.content[0] as any;
-    expect(compactionBlock.content).toBe("Summary part 1 part 2 part 3");
-    expect(compactionBlock.encrypted_content).toBe("ck_point_2");
+    expect(compactionBlock.content).toBe('Summary part 1 part 2 part 3');
+    expect(compactionBlock.encrypted_content).toBe('ck_point_2');
   });
 
-  it("does not re-emit compaction for a checkpoint-only delta", async () => {
+  it('does not re-emit compaction for a checkpoint-only delta', async () => {
     const { fetch, handleStreamEvents } = mockFetch();
-    const anthropic = new Anthropic({ apiKey: "test-key", fetch });
+    const anthropic = new Anthropic({ apiKey: 'test-key', fetch });
 
     handleStreamEvents([
       {
-        type: "message_start",
+        type: 'message_start',
         message: {
-          id: "msg_compact_02",
-          type: "message",
-          role: "assistant",
+          id: 'msg_compact_02',
+          type: 'message',
+          role: 'assistant',
           content: [],
-          model: "claude-sonnet-4-5",
+          model: 'claude-sonnet-4-5',
           stop_reason: null,
           stop_sequence: null,
           usage: { input_tokens: 10, output_tokens: 1 },
         },
       },
       {
-        type: "content_block_start",
+        type: 'content_block_start',
         index: 0,
-        content_block: { type: "compaction", content: "", encrypted_content: "" },
+        content_block: { type: 'compaction', content: '', encrypted_content: '' },
       },
       {
-        type: "content_block_delta",
+        type: 'content_block_delta',
         index: 0,
-        delta: { type: "compaction_delta", content: "Summary part 1", encrypted_content: "ck_point_1" },
+        delta: { type: 'compaction_delta', content: 'Summary part 1', encrypted_content: 'ck_point_1' },
       },
       {
-        type: "content_block_delta",
+        type: 'content_block_delta',
         index: 0,
-        delta: { type: "compaction_delta", content: " part 2", encrypted_content: null },
+        delta: { type: 'compaction_delta', content: ' part 2', encrypted_content: null },
       },
       {
-        type: "content_block_delta",
+        type: 'content_block_delta',
         index: 0,
-        delta: { type: "compaction_delta", content: null, encrypted_content: "ck_point_2" },
+        delta: { type: 'compaction_delta', content: null, encrypted_content: 'ck_point_2' },
       },
       {
-        type: "content_block_delta",
+        type: 'content_block_delta',
         index: 0,
-        delta: { type: "compaction_delta", content: " part 3", encrypted_content: null },
+        delta: { type: 'compaction_delta', content: ' part 3', encrypted_content: null },
       },
-      { type: "content_block_stop", index: 0 },
+      { type: 'content_block_stop', index: 0 },
       {
-        type: "message_delta",
-        delta: { stop_reason: "end_turn", stop_sequence: null },
+        type: 'message_delta',
+        delta: { stop_reason: 'end_turn', stop_sequence: null },
         usage: { output_tokens: 10 },
       },
-      { type: "message_stop" },
+      { type: 'message_stop' },
     ]);
 
     const stream = anthropic.beta.messages.stream({
       max_tokens: 1024,
-      model: "claude-sonnet-4-5",
-      messages: [{ role: "user", content: "test" }],
+      model: 'claude-sonnet-4-5',
+      messages: [{ role: 'user', content: 'test' }],
     });
 
     const emitted: string[] = [];
-    stream.on("compaction", (compacted) => emitted.push(compacted));
+    stream.on('compaction', (compacted) => emitted.push(compacted));
     await stream.finalMessage();
 
-    expect(emitted).toEqual([
-      "Summary part 1",
-      "Summary part 1 part 2",
-      "Summary part 1 part 2 part 3",
+    expect(emitted).toEqual(['Summary part 1', 'Summary part 1 part 2', 'Summary part 1 part 2 part 3']);
+  });
+
+  it('compaction that starts null and only ever gets checkpoints stays null', async () => {
+    const { fetch, handleStreamEvents } = mockFetch();
+    const anthropic = new Anthropic({ apiKey: 'test-key', fetch });
+
+    handleStreamEvents([
+      {
+        type: 'message_start',
+        message: {
+          id: 'msg_probe',
+          type: 'message',
+          role: 'assistant',
+          content: [],
+          model: 'claude-sonnet-4-5',
+          stop_reason: null,
+          stop_sequence: null,
+          usage: { input_tokens: 10, output_tokens: 1 },
+        },
+      },
+      {
+        type: 'content_block_start',
+        index: 0,
+        content_block: { type: 'compaction', content: null, encrypted_content: 'ck_0' },
+      },
+      {
+        type: 'content_block_delta',
+        index: 0,
+        delta: { type: 'compaction_delta', content: null, encrypted_content: 'ck_1' },
+      },
+      { type: 'content_block_stop', index: 0 },
+      {
+        type: 'message_delta',
+        delta: { stop_reason: 'end_turn', stop_sequence: null },
+        usage: { output_tokens: 10 },
+      },
+      { type: 'message_stop' },
     ]);
+
+    const stream = anthropic.beta.messages.stream({
+      max_tokens: 1024,
+      model: 'claude-sonnet-4-5',
+      messages: [{ role: 'user', content: 'test' }],
+    });
+    const emitted: string[] = [];
+    stream.on('compaction', (c) => emitted.push(c));
+    const block = (await stream.finalMessage()).content[0] as any;
+
+    expect(block.content).toBeNull();
+    expect(block.encrypted_content).toBe('ck_1');
+    expect(emitted).toEqual([]);
   });
 });

--- a/tests/api-resources/BetaMessageStream.test.ts
+++ b/tests/api-resources/BetaMessageStream.test.ts
@@ -829,6 +829,15 @@ describe('BetaMessageStream class', () => {
           encrypted_content: "ck_point_2",
         },
       },
+      {
+        type: "content_block_delta",
+        index: 0,
+        delta: {
+          type: "compaction_delta",
+          content: " part 3",
+          encrypted_content: null,
+        },
+      },
       { type: "content_block_stop", index: 0 },
       {
         type: "message_delta",
@@ -846,7 +855,76 @@ describe('BetaMessageStream class', () => {
 
     const finalMessage = await stream.finalMessage();
     const compactionBlock = finalMessage.content[0] as any;
-    expect(compactionBlock.content).toBe("Summary part 1 part 2");
+    expect(compactionBlock.content).toBe("Summary part 1 part 2 part 3");
     expect(compactionBlock.encrypted_content).toBe("ck_point_2");
+  });
+
+  it("does not re-emit compaction for a checkpoint-only delta", async () => {
+    const { fetch, handleStreamEvents } = mockFetch();
+    const anthropic = new Anthropic({ apiKey: "test-key", fetch });
+
+    handleStreamEvents([
+      {
+        type: "message_start",
+        message: {
+          id: "msg_compact_02",
+          type: "message",
+          role: "assistant",
+          content: [],
+          model: "claude-sonnet-4-5",
+          stop_reason: null,
+          stop_sequence: null,
+          usage: { input_tokens: 10, output_tokens: 1 },
+        },
+      },
+      {
+        type: "content_block_start",
+        index: 0,
+        content_block: { type: "compaction", content: "", encrypted_content: "" },
+      },
+      {
+        type: "content_block_delta",
+        index: 0,
+        delta: { type: "compaction_delta", content: "Summary part 1", encrypted_content: "ck_point_1" },
+      },
+      {
+        type: "content_block_delta",
+        index: 0,
+        delta: { type: "compaction_delta", content: " part 2", encrypted_content: null },
+      },
+      {
+        type: "content_block_delta",
+        index: 0,
+        delta: { type: "compaction_delta", content: null, encrypted_content: "ck_point_2" },
+      },
+      {
+        type: "content_block_delta",
+        index: 0,
+        delta: { type: "compaction_delta", content: " part 3", encrypted_content: null },
+      },
+      { type: "content_block_stop", index: 0 },
+      {
+        type: "message_delta",
+        delta: { stop_reason: "end_turn", stop_sequence: null },
+        usage: { output_tokens: 10 },
+      },
+      { type: "message_stop" },
+    ]);
+
+    const stream = anthropic.beta.messages.stream({
+      max_tokens: 1024,
+      model: "claude-sonnet-4-5",
+      messages: [{ role: "user", content: "test" }],
+    });
+
+    const emitted: string[] = [];
+    stream.on("compaction", (compacted) => emitted.push(compacted));
+    await stream.finalMessage();
+
+    expect(emitted).toEqual([
+      "Summary part 1",
+      "Summary part 1 part 2",
+      "Summary part 1 part 2 part 3",
+    ]);
   });
 });

--- a/tests/api-resources/BetaMessageStream.test.ts
+++ b/tests/api-resources/BetaMessageStream.test.ts
@@ -820,6 +820,15 @@ describe('BetaMessageStream class', () => {
           encrypted_content: null,
         },
       },
+      {
+        type: "content_block_delta",
+        index: 0,
+        delta: {
+          type: "compaction_delta",
+          content: null,
+          encrypted_content: "ck_point_2",
+        },
+      },
       { type: "content_block_stop", index: 0 },
       {
         type: "message_delta",
@@ -838,6 +847,6 @@ describe('BetaMessageStream class', () => {
     const finalMessage = await stream.finalMessage();
     const compactionBlock = finalMessage.content[0] as any;
     expect(compactionBlock.content).toBe("Summary part 1 part 2");
-    expect(compactionBlock.encrypted_content).toBe("ck_point_1");
+    expect(compactionBlock.encrypted_content).toBe("ck_point_2");
   });
 });

--- a/tests/api-resources/BetaMessageStream.test.ts
+++ b/tests/api-resources/BetaMessageStream.test.ts
@@ -777,4 +777,67 @@ describe('BetaMessageStream class', () => {
       { type: 'text', text: 'Hello there!' },
     ]);
   });
+
+  it("accumulates compaction_delta events without coercing null or dropping checkpoint", async () => {
+    const { fetch, handleStreamEvents } = mockFetch();
+
+    const anthropic = new Anthropic({ apiKey: "test-key", fetch });
+
+    handleStreamEvents([
+      {
+        type: "message_start",
+        message: {
+          id: "msg_compact_01",
+          type: "message",
+          role: "assistant",
+          content: [],
+          model: "claude-sonnet-4-5",
+          stop_reason: null,
+          stop_sequence: null,
+          usage: { input_tokens: 10, output_tokens: 1 },
+        },
+      },
+      {
+        type: "content_block_start",
+        index: 0,
+        content_block: { type: "compaction", content: "", encrypted_content: "" },
+      },
+      {
+        type: "content_block_delta",
+        index: 0,
+        delta: {
+          type: "compaction_delta",
+          content: "Summary part 1",
+          encrypted_content: "ck_point_1",
+        },
+      },
+      {
+        type: "content_block_delta",
+        index: 0,
+        delta: {
+          type: "compaction_delta",
+          content: " part 2",
+          encrypted_content: null,
+        },
+      },
+      { type: "content_block_stop", index: 0 },
+      {
+        type: "message_delta",
+        delta: { stop_reason: "end_turn", stop_sequence: null },
+        usage: { output_tokens: 10 },
+      },
+      { type: "message_stop" },
+    ]);
+
+    const stream = anthropic.beta.messages.stream({
+      max_tokens: 1024,
+      model: "claude-sonnet-4-5",
+      messages: [{ role: "user", content: "test" }],
+    });
+
+    const finalMessage = await stream.finalMessage();
+    const compactionBlock = finalMessage.content[0] as any;
+    expect(compactionBlock.content).toBe("Summary part 1 part 2");
+    expect(compactionBlock.encrypted_content).toBe("ck_point_1");
+  });
 });


### PR DESCRIPTION
## Summary

Fixes #1164.

In `BetaMessageStream.ts`, handling of `compaction_delta` had two issues:
1. `content` concatenation did not check for `null`, coercing `null` into string `"null"` when concatenated with strings.
2. `encrypted_content` unconditionally overwrote previous values, so a delta with `encrypted_content: null` cleared any previously established checkpoint.

## Solution

- In `compaction_delta`, preserve `snapshotContent.content` if `event.delta.content === null`, otherwise concatenate onto `snapshotContent.content ?? ''`.
- Preserve existing `snapshotContent.encrypted_content` when `event.delta.encrypted_content` is `null` / `undefined`.
- Add unit tests in `tests/api-resources/BetaMessageStream.test.ts` verifying compaction delta accumulation.

## Testing

- Tested with `pnpm jest tests/api-resources/BetaMessageStream.test.ts` (RED -> GREEN verified).