### PR TITLE
fix(beta): preserve tool turn for param updates

### DIFF
--- a/src/lib/tools/BetaToolRunner.ts
+++ b/src/lib/tools/BetaToolRunner.ts
@@ -34,8 +34,8 @@ import {
 export class BetaToolRunner<Stream extends boolean> {
   /** Whether the async iterator has been consumed */
   #consumed = false;
-  /** Whether parameters have been mutated since the last API call */
-  #mutated = false;
+  /** Whether messages have been mutated since the last API call */
+  #messagesMutated = false;
   /** Current state containing the request parameters */
   #state: { params: BetaToolRunnerParams };
   #options: BetaToolRunnerRequestOptions;
@@ -183,7 +183,7 @@ export class BetaToolRunner<Stream extends boolean> {
     }
 
     this.#consumed = true;
-    this.#mutated = true;
+    this.#messagesMutated = true;
     this.#toolResponse = undefined;
 
     try {
@@ -197,7 +197,7 @@ export class BetaToolRunner<Stream extends boolean> {
             break;
           }
 
-          this.#mutated = false;
+          this.#messagesMutated = false;
           this.#toolResponse = undefined;
           this.#iterationCount++;
           this.#message = undefined;
@@ -218,7 +218,7 @@ export class BetaToolRunner<Stream extends boolean> {
 
           const isCompacted = await this.#checkAndCompact();
           if (!isCompacted) {
-            if (!this.#mutated) {
+            if (!this.#messagesMutated) {
               const message = await this.#message;
               this.#state.params.messages.push({ role: message.role, content: message.content });
 
@@ -246,7 +246,7 @@ export class BetaToolRunner<Stream extends boolean> {
             const toolMessage = await this.#generateToolResponse(this.#state.params.messages.at(-1)!);
             if (toolMessage) {
               this.#state.params.messages.push(toolMessage);
-            } else if (!this.#mutated) {
+            } else if (!this.#messagesMutated) {
               break;
             }
           }
@@ -296,12 +296,13 @@ export class BetaToolRunner<Stream extends boolean> {
   setMessagesParams(
     paramsOrMutator: BetaToolRunnerParams | ((prevParams: BetaToolRunnerParams) => BetaToolRunnerParams),
   ) {
+    const previousMessages = this.#state.params.messages;
     if (typeof paramsOrMutator === 'function') {
       this.#state.params = paramsOrMutator(this.#state.params);
     } else {
       this.#state.params = paramsOrMutator;
     }
-    this.#mutated = true;
+    this.#messagesMutated ||= this.#state.params.messages !== previousMessages;
     // Invalidate cached tool response since parameters changed
     this.#toolResponse = undefined;
   }

--- a/tests/lib/tools/BetaToolRunner.test.ts
+++ b/tests/lib/tools/BetaToolRunner.test.ts
@@ -1022,6 +1022,85 @@ describe('ToolRunner', () => {
       await expectDone(iterator);
     });
 
+    it.each([false, true])(
+      'preserves the current tool-use turn after updating non-message params (stream=%s)',
+      async (stream) => {
+        let runCount = 0;
+        const trackedWeatherTool: BetaRunnableTool<{ location: string }> = {
+          ...weatherTool,
+          run: async ({ location }) => {
+            runCount++;
+            return `Sunny in ${location}`;
+          },
+        };
+        const setup =
+          stream ?
+            setupTest({ max_tokens: 100, tools: [trackedWeatherTool], stream: true })
+          : setupTest({ max_tokens: 100, tools: [trackedWeatherTool] });
+        const iterator: AsyncIterator<any> = setup.runner[Symbol.asyncIterator]();
+
+        stream ?
+          setup.handleAssistantMessageStream(getWeatherToolUse('SF'))
+        : setup.handleAssistantMessage(getWeatherToolUse('SF'));
+        await expectEvent(iterator);
+
+        setup.runner.setMessagesParams((params) => ({ ...params, max_tokens: 200 }));
+
+        let followupBody: Record<string, unknown> | undefined;
+        setup.handleRequest(async (_req, init) => {
+          followupBody = JSON.parse(init!.body as string);
+          const finalMessage: BetaMessage = {
+            id: 'msg_done',
+            type: 'message',
+            role: 'assistant',
+            content: [getTextContent()],
+            model: 'claude-3-5-sonnet-latest',
+            stop_details: null,
+            stop_reason: 'end_turn',
+            stop_sequence: null,
+            container: null,
+            context_management: null,
+            diagnostics: null,
+            usage: {
+              input_tokens: 10,
+              output_tokens: 5,
+              output_tokens_details: null,
+              cache_creation: null,
+              cache_creation_input_tokens: null,
+              cache_read_input_tokens: null,
+              fallback_credit: null,
+              server_tool_use: null,
+              service_tier: null,
+              inference_geo: null,
+              iterations: null,
+              speed: null,
+            },
+          };
+          if (stream) {
+            const sse = betaMessageToStreamEvents(finalMessage)
+              .map((event) => `event: ${event.type}\ndata: ${JSON.stringify(event)}\n\n`)
+              .join('');
+            return new Response(sse, { headers: { 'content-type': 'text/event-stream' } });
+          }
+          return new Response(JSON.stringify(finalMessage), {
+            headers: { 'content-type': 'application/json' },
+          });
+        });
+
+        await expectEvent(iterator);
+        await expectDone(iterator);
+
+        expect(runCount).toBe(1);
+        expect(followupBody?.['max_tokens']).toBe(200);
+        expect(followupBody?.['messages']).toHaveLength(3);
+        expect(followupBody?.['messages']).toMatchObject([
+          { role: 'user', content: 'What is the weather?' },
+          { role: 'assistant', content: [getWeatherToolUse('SF')] },
+          { role: 'user', content: [getWeatherToolResult('SF')] },
+        ]);
+      },
+    );
+
     it('allows you to update append custom tool_use blocks', async () => {
       const { runner, handleAssistantMessage } = setupTest({
         messages: [{ role: 'user', content: 'Get weather' }],


### PR DESCRIPTION
## What
Fixes #964. `setMessagesParams()` could drop the current assistant tool-use turn when only request params like `max_tokens` changed.

## Fix
Track whether the messages array changed separately from other param updates, so non-message updates still let the runner append the assistant turn and generated tool result.

## Test
Adds stream and non-stream regression cases that update `max_tokens` between tool-use turns.