### PR TITLE
fix(credentials): stop superseded token refreshes from committing stale results

### DIFF
--- a/src/lib/credentials/token-cache.ts
+++ b/src/lib/credentials/token-cache.ts
@@ -27,6 +27,10 @@ export class TokenCache {
   private cached: AccessToken | null = null;
   private pendingRefresh: Promise<AccessToken> | null = null;
   private nextForce = false;
+  /** Increments on every new refresh and on invalidate(), so a slower
+   *  superseded refresh can no longer commit its (older) token over a
+   *  newer one. */
+  private generation = 0;
   private lastAdvisoryError = 0;
   private onAdvisoryRefreshError: ((err: unknown) => void) | undefined;
 
@@ -71,6 +75,9 @@ export class TokenCache {
    * if its `expires_at` still looks fresh.
    */
   invalidate(): void {
+    // Any refresh still in flight was started before the invalidation and
+    // must not commit its result over the forced refresh that follows.
+    this.generation++;
     this.cached = null;
     this.nextForce = true;
   }
@@ -114,14 +121,22 @@ export class TokenCache {
    * (both advisory and mandatory) coalesce into a single provider call.
    */
   private doRefresh(force = false): Promise<AccessToken> {
+    const generation = ++this.generation;
     this.pendingRefresh = this.provider(force ? { forceRefresh: true } : undefined).then(
       (token) => {
+        if (generation !== this.generation) {
+          // A forced refresh or invalidate() superseded this one; committing
+          // would overwrite the newer token with an older one.
+          return token;
+        }
         this.cached = token;
         this.pendingRefresh = null;
         return token;
       },
       (err) => {
-        this.pendingRefresh = null;
+        if (generation === this.generation) {
+          this.pendingRefresh = null;
+        }
         throw err;
       },
     );

--- a/tests/lib/credentials/token-cache.test.ts
+++ b/tests/lib/credentials/token-cache.test.ts
@@ -43,6 +43,64 @@ describe('TokenCache', () => {
     expect(provider).toHaveBeenCalledTimes(1);
   });
 
+  function deferredToken() {
+    let resolve!: (t: AccessToken) => void;
+    const promise = new Promise<AccessToken>((res) => {
+      resolve = res;
+    });
+    return { promise, resolve };
+  }
+
+  it('a slower superseded refresh cannot overwrite a newer forced result', async () => {
+    const calls: Array<{ forceRefresh?: boolean } | undefined> = [];
+    const hung = deferredToken();
+    const provider = jest.fn((opts?: { forceRefresh?: boolean }) => {
+      calls.push(opts);
+      if (opts?.forceRefresh) {
+        return Promise.resolve({ token: 'fresh', expiresAt: fakeNow + 3600 });
+      }
+      return hung.promise;
+    }) as unknown as jest.Mock;
+    const cache = new TokenCache(provider as never);
+
+    // Plain refresh starts and hangs (call 1, non-forced).
+    const first = cache.getToken();
+    expect(calls[0]?.forceRefresh).toBeUndefined();
+
+    // A 401 lands elsewhere: invalidate forces the next fetch to bypass the
+    // hang instead of coalescing into it.
+    cache.invalidate();
+    expect(await cache.getToken()).toBe('fresh');
+
+    // The hung refresh finally settles with an older token. It must not
+    // commit over the forced result.
+    hung.resolve({ token: 'stale', expiresAt: fakeNow + 3600 });
+    await first;
+
+    expect(await cache.getToken()).toBe('fresh');
+  });
+
+  it('discards an in-flight refresh invalidated mid-flight', async () => {
+    const hung = deferredToken();
+    const provider = jest.fn((opts?: { forceRefresh?: boolean }) => {
+      if (opts?.forceRefresh) {
+        return Promise.resolve({ token: 'fresh', expiresAt: fakeNow + 3600 });
+      }
+      return hung.promise;
+    }) as unknown as jest.Mock;
+    const cache = new TokenCache(provider as never);
+
+    const first = cache.getToken(); // starts a plain refresh, hangs
+    cache.invalidate(); // e.g. a concurrent request just saw a 401
+    hung.resolve({ token: 'stale', expiresAt: fakeNow + 3600 });
+    await first.catch(() => {});
+
+    // A forced refresh lands after the stale result settled; the stale
+    // generation must not overwrite it.
+    expect(await cache.getToken()).toBe('fresh');
+    expect(await cache.getToken()).toBe('fresh');
+  });
+
   it('caches forever when expiresAt is null', async () => {
     const provider = jest.fn<Promise<AccessToken>, []>().mockResolvedValue({
       token: 'eternal',


### PR DESCRIPTION
## What

`TokenCache` guards against a forced refresh coalescing into an in-flight non-forced one, but the non-forced refresh's own completion handler still unconditionally committed `this.cached`. A slower superseded refresh could therefore overwrite the newer token after it had already been cached.

## Why

Concrete interleaving with the current code:

1. Request A triggers a plain refresh (call 1, in flight).
2. A concurrent request gets a 401 → `invalidate()` bumps state, or request B forces a refresh (call 2).
3. Call 1 settles **after** call 2 and its completion handler writes its (older, disk-cached) token into `this.cached`.

The next `getToken()` then serves the stale token that was just rejected with a 401, repeating the loop. The existing doc comment on `refresh()` already identifies half of this hazard ("may re-serve the same stale disk token") but only the coalescing side was guarded.

## Change

Add a monotonically increasing `generation` counter:

- `invalidate()` and every new `doRefresh()` supersede older generations.
- Only the latest generation may commit `cached` / clear `pendingRefresh`; superseded completions return their result to their own awaiter without touching shared state.

Two regression tests cover the forced-overwrite race and the invalidated-mid-flight case; both fail on main and pass here.