### PR TITLE
fix: preserve defs when schema root is a ref, and fix compaction delta null content

### DIFF
--- a/src/lib/BetaMessageStream.ts
+++ b/src/lib/BetaMessageStream.ts
@@ -495,7 +495,7 @@ export class BetaMessageStream<ParsedT = null> implements AsyncIterable<BetaMess
             break;
           }
           case 'compaction_delta': {
-            if (content.type === 'compaction' && content.content) {
+            if (content.type === 'compaction' && content.content && event.delta.content !== null) {
               this._emit('compaction', content.content);
             }
             break;

--- a/src/lib/BetaMessageStream.ts
+++ b/src/lib/BetaMessageStream.ts
@@ -495,7 +495,7 @@ export class BetaMessageStream<ParsedT = null> implements AsyncIterable<BetaMess
             break;
           }
           case 'compaction_delta': {
-            if (content.type === 'compaction' && content.content && event.delta.content !== null) {
+            if (content.type === 'compaction' && content.content && event.delta.content != null) {
               this._emit('compaction', content.content);
             }
             break;

--- a/src/lib/BetaMessageStream.ts
+++ b/src/lib/BetaMessageStream.ts
@@ -693,8 +693,11 @@ export class BetaMessageStream<ParsedT = null> implements AsyncIterable<BetaMess
             if (snapshotContent?.type === 'compaction') {
               snapshot.content[event.index] = {
                 ...snapshotContent,
-                content: (snapshotContent.content || '') + event.delta.content,
-                encrypted_content: event.delta.encrypted_content,
+                content:
+                  event.delta.content != null ?
+                    (snapshotContent.content ?? '') + event.delta.content
+                  : snapshotContent.content ?? null,
+                encrypted_content: event.delta.encrypted_content ?? snapshotContent.encrypted_content,
               };
             }
             break;

--- a/src/lib/transform-json-schema.ts
+++ b/src/lib/transform-json-schema.ts
@@ -28,12 +28,6 @@ export function transformJSONSchema(jsonSchema: JSONSchema): JSONSchema {
 function _transformJSONSchema(jsonSchema: JSONSchema): JSONSchema {
   const strictSchema: JSONSchema = {};
 
-  const ref = pop(jsonSchema, '$ref');
-  if (ref !== undefined) {
-    strictSchema['$ref'] = ref;
-    return strictSchema;
-  }
-
   const defs = pop(jsonSchema, '$defs');
   if (defs !== undefined) {
     const strictDefs: Record<string, any> = {};
@@ -41,6 +35,21 @@ function _transformJSONSchema(jsonSchema: JSONSchema): JSONSchema {
     for (const [name, defSchema] of Object.entries(defs)) {
       strictDefs[name] = _transformJSONSchema(defSchema as JSONSchema);
     }
+  }
+
+  const definitions = pop(jsonSchema, 'definitions');
+  if (definitions !== undefined) {
+    const strictDefinitions: Record<string, any> = {};
+    strictSchema['definitions'] = strictDefinitions;
+    for (const [name, defSchema] of Object.entries(definitions)) {
+      strictDefinitions[name] = _transformJSONSchema(defSchema as JSONSchema);
+    }
+  }
+
+  const ref = pop(jsonSchema, '$ref');
+  if (ref !== undefined) {
+    strictSchema['$ref'] = ref;
+    return strictSchema;
   }
 
   const type = pop(jsonSchema, 'type');

--- a/tests/api-resources/BetaMessageStream.test.ts
+++ b/tests/api-resources/BetaMessageStream.test.ts
@@ -897,6 +897,15 @@ describe('BetaMessageStream class', () => {
         },
       },
       {
+        type: 'content_block_delta',
+        index: 0,
+        delta: {
+          type: 'compaction_delta',
+          content: null,
+          encrypted_content: 'checkpoint_token_v2',
+        },
+      },
+      {
         type: 'content_block_stop',
         index: 0,
       },
@@ -928,7 +937,7 @@ describe('BetaMessageStream class', () => {
       {
         type: 'compaction',
         content: 'Part 1. Part 2.',
-        encrypted_content: 'checkpoint_token',
+        encrypted_content: 'checkpoint_token_v2',
       },
     ]);
   });

--- a/tests/api-resources/BetaMessageStream.test.ts
+++ b/tests/api-resources/BetaMessageStream.test.ts
@@ -777,4 +777,159 @@ describe('BetaMessageStream class', () => {
       { type: 'text', text: 'Hello there!' },
     ]);
   });
+
+  it('handles compaction_delta with null content without coercing to "null"', async () => {
+    const { fetch, handleStreamEvents } = mockFetch();
+    const anthropic = new Anthropic({ apiKey: 'test-key', fetch });
+
+    handleStreamEvents([
+      {
+        type: 'message_start',
+        message: {
+          type: 'message',
+          id: 'msg_test_compaction',
+          role: 'assistant',
+          content: [],
+          model: 'claude-opus-4-8',
+          stop_reason: null,
+          stop_sequence: null,
+          usage: { output_tokens: 0, input_tokens: 10 },
+        },
+      },
+      {
+        type: 'content_block_start',
+        index: 0,
+        content_block: {
+          type: 'compaction',
+          content: null,
+          encrypted_content: 'opaque_checkpoint_data',
+        },
+      },
+      {
+        type: 'content_block_delta',
+        index: 0,
+        delta: {
+          type: 'compaction_delta',
+          content: null,
+          encrypted_content: null,
+        },
+      },
+      {
+        type: 'content_block_stop',
+        index: 0,
+      },
+      {
+        type: 'message_delta',
+        usage: { output_tokens: 5 },
+        delta: { stop_reason: 'end_turn', stop_sequence: null },
+      },
+      {
+        type: 'message_stop',
+      },
+    ]);
+
+    const compactionEvents: string[] = [];
+    const stream = anthropic.beta.messages.stream({
+      max_tokens: 1024,
+      model: 'claude-opus-4-8',
+      messages: [{ role: 'user', content: 'test' }],
+    });
+
+    stream.on('compaction', (compactedContent) => {
+      compactionEvents.push(compactedContent);
+    });
+
+    const finalMessage = await stream.finalMessage();
+
+    expect(compactionEvents).toEqual([]);
+    expect(finalMessage.content).toEqual([
+      {
+        type: 'compaction',
+        content: null,
+        encrypted_content: 'opaque_checkpoint_data',
+      },
+    ]);
+  });
+
+  it('accumulates non-null compaction_delta content and emits compaction event', async () => {
+    const { fetch, handleStreamEvents } = mockFetch();
+    const anthropic = new Anthropic({ apiKey: 'test-key', fetch });
+
+    handleStreamEvents([
+      {
+        type: 'message_start',
+        message: {
+          type: 'message',
+          id: 'msg_test_compaction',
+          role: 'assistant',
+          content: [],
+          model: 'claude-opus-4-8',
+          stop_reason: null,
+          stop_sequence: null,
+          usage: { output_tokens: 0, input_tokens: 10 },
+        },
+      },
+      {
+        type: 'content_block_start',
+        index: 0,
+        content_block: {
+          type: 'compaction',
+          content: null,
+          encrypted_content: null,
+        },
+      },
+      {
+        type: 'content_block_delta',
+        index: 0,
+        delta: {
+          type: 'compaction_delta',
+          content: 'Part 1. ',
+          encrypted_content: 'checkpoint_token',
+        },
+      },
+      {
+        type: 'content_block_delta',
+        index: 0,
+        delta: {
+          type: 'compaction_delta',
+          content: 'Part 2.',
+          encrypted_content: null,
+        },
+      },
+      {
+        type: 'content_block_stop',
+        index: 0,
+      },
+      {
+        type: 'message_delta',
+        usage: { output_tokens: 5 },
+        delta: { stop_reason: 'end_turn', stop_sequence: null },
+      },
+      {
+        type: 'message_stop',
+      },
+    ]);
+
+    const compactionEvents: string[] = [];
+    const stream = anthropic.beta.messages.stream({
+      max_tokens: 1024,
+      model: 'claude-opus-4-8',
+      messages: [{ role: 'user', content: 'test' }],
+    });
+
+    stream.on('compaction', (compactedContent) => {
+      compactionEvents.push(compactedContent);
+    });
+
+    const finalMessage = await stream.finalMessage();
+
+    expect(compactionEvents).toEqual(['Part 1. ', 'Part 1. Part 2.']);
+    expect(finalMessage.content).toEqual([
+      {
+        type: 'compaction',
+        content: 'Part 1. Part 2.',
+        encrypted_content: 'checkpoint_token',
+      },
+    ]);
+  });
 });

--- a/tests/api-resources/BetaMessageStream.test.ts
+++ b/tests/api-resources/BetaMessageStream.test.ts
@@ -906,6 +906,14 @@ describe('BetaMessageStream class', () => {
         },
       },
       {
+        type: 'content_block_delta',
+        index: 0,
+        delta: {
+          type: 'compaction_delta',
+          encrypted_content: 'checkpoint_token_v3',
+        } as any,
+      },
+      {
         type: 'content_block_stop',
         index: 0,
       },
@@ -937,8 +945,64 @@ describe('BetaMessageStream class', () => {
       {
         type: 'compaction',
         content: 'Part 1. Part 2.',
-        encrypted_content: 'checkpoint_token_v2',
+        encrypted_content: 'checkpoint_token_v3',
       },
     ]);
+  });
+
+  it('compaction that starts null and only ever gets checkpoints stays null', async () => {
+    const { fetch, handleStreamEvents } = mockFetch();
+    const anthropic = new Anthropic({ apiKey: 'test-key', fetch });
+
+    handleStreamEvents([
+      {
+        type: 'message_start',
+        message: {
+          id: 'msg_probe',
+          type: 'message',
+          role: 'assistant',
+          content: [],
+          model: 'claude-sonnet-4-5',
+          stop_reason: null,
+          stop_sequence: null,
+          usage: { input_tokens: 10, output_tokens: 1 },
+        },
+      },
+      {
+        type: 'content_block_start',
+        index: 0,
+        content_block: { type: 'compaction', content: null, encrypted_content: 'ck_0' },
+      },
+      {
+        type: 'content_block_delta',
+        index: 0,
+        delta: { type: 'compaction_delta', content: null, encrypted_content: 'ck_1' },
+      },
+      {
+        type: 'content_block_stop',
+        index: 0,
+      },
+      {
+        type: 'message_delta',
+        delta: { stop_reason: 'end_turn', stop_sequence: null },
+        usage: { output_tokens: 10 },
+      },
+      {
+        type: 'message_stop',
+      },
+    ]);
+
+    const stream = anthropic.beta.messages.stream({
+      max_tokens: 1024,
+      model: 'claude-sonnet-4-5',
+      messages: [{ role: 'user', content: 'test' }],
+    });
+    const emitted: string[] = [];
+    stream.on('compaction', (c) => emitted.push(c));
+    const block = (await stream.finalMessage()).content[0] as any;
+
+    expect(block.content).toBeNull();
+    expect(block.encrypted_content).toBe('ck_1');
+    expect(emitted).toEqual([]);
   });
 });

--- a/tests/helpers/transform-json-schema.test.ts
+++ b/tests/helpers/transform-json-schema.test.ts
@@ -480,4 +480,67 @@ describe('transformJsonSchema', () => {
 }
 `);
   });
+
+  it('should preserve $defs when schema root is a $ref', () => {
+    const input = {
+      $ref: '#/$defs/Item',
+      $defs: {
+        Item: {
+          type: 'object',
+          properties: {
+            id: { type: 'string' },
+            count: { type: 'integer', minimum: 1 },
+          },
+          required: ['id'],
+        },
+      },
+    };
+
+    const result = transformJSONSchema(input);
+    expect(result).toEqual({
+      $ref: '#/$defs/Item',
+      $defs: {
+        Item: {
+          type: 'object',
+          properties: {
+            id: { type: 'string' },
+            count: {
+              type: 'integer',
+              description: '{minimum: 1}',
+            },
+          },
+          required: ['id'],
+          additionalProperties: false,
+        },
+      },
+    });
+  });
+
+  it('should preserve definitions when schema root is a $ref', () => {
+    const input = {
+      $ref: '#/definitions/Item',
+      definitions: {
+        Item: {
+          type: 'object',
+          properties: {
+            name: { type: 'string' },
+          },
+        },
+      },
+    };
+
+    const result = transformJSONSchema(input);
+    expect(result).toEqual({
+      $ref: '#/definitions/Item',
+      definitions: {
+        Item: {
+          type: 'object',
+          properties: {
+            name: { type: 'string' },
+          },
+          additionalProperties: false,
+        },
+      },
+    });
+  });
 });


### PR DESCRIPTION
## Summary

1. **Issue #1162**: `transformJSONSchema` previously performed an early return when encountering a `$ref`, which caused top-level `$defs` and `definitions` to be discarded when the schema root was a `$ref`. Reordered processing so `$defs` and `definitions` are transformed and retained on the returned strict schema.
2. **Issue #1164**: `BetaMessageStream` previously coerced `null` `content` in `compaction_delta` events into the string `"null"` via string concatenation (`'' + null`). Fixed delta accumulation to preserve `null` content properly and keep `encrypted_content` intact across deltas.

## Test Plan
- Added unit tests in `tests/helpers/transform-json-schema.test.ts` verifying `$defs` and `definitions` preservation when root schema is a `$ref`.
- Added unit tests in `tests/api-resources/BetaMessageStream.test.ts` verifying `compaction_delta` null content handling and non-null accumulation.
- Ran `npm run lint` and verified test suite passes.