### PR TITLE
fix(tool runner): don't exit early on pause_turn

### DIFF
--- a/src/lib/tools/BetaToolRunner.ts
+++ b/src/lib/tools/BetaToolRunner.ts
@@ -247,8 +247,11 @@ export class BetaToolRunner<Stream extends boolean> {
             const toolMessage = await this.#generateToolResponse(this.#state.params.messages.at(-1)!);
             if (toolMessage) {
               this.#state.params.messages.push(toolMessage);
-            } else if (!this.#mutated) {
-              break;
+            } else {
+              const message = await this.#message;
+              if (!this.#mutated && message.stop_reason !== 'pause_turn') {
+                break;
+              }
             }
           }
         } finally {


### PR DESCRIPTION
## Problem

The tool runner was exiting early when encountering a `pause_turn` stop reason, preventing it from continuing the conversation loop.

`pause_turn` means the API paused some operation and wants the client to send back the message to continue it, which is why we should send it back instead of just exiting the loop.

## Fix

When `pause_turn` is received and there is no tool message generated, the runner should continue the loop instead of breaking. This is achieved by checking if `stop_reason` is `pause_turn` before breaking in the else block after tool response generation.

Fixes #906